### PR TITLE
feat(marker): --marker-args passthrough, streamed progress, table-fidelity counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,53 @@ The de-join step uses `pyspellchecker` (installed by `requirements.txt`). If
 it is ever missing, cleanup degrades gracefully — the dictionary-free repairs
 still run and a warning is recorded.
 
+### Passing flags through to marker
+
+The marker backend accepts extra flags via `--marker-args`, forwarded
+verbatim to `marker_single`:
+
+```bash
+python convert.py input/MyBook.pdf --method marker --marker-args '--use_llm'
+python convert.py input/MyBook.pdf --method marker --marker-args '--html_tables_in_markdown'
+```
+
+The two that matter for table-heavy books:
+
+- `--use_llm` activates marker's LLM table processors, which fix merged
+  headers and rows split across lines. It needs an LLM service
+  configured (`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, or a local ollama
+  endpoint) — see `marker_single --help` for `--llm_service`.
+- `--html_tables_in_markdown` emits `<table>` with real `colspan` /
+  `rowspan`. GFM markdown cannot express spanning header cells at all,
+  so this is the only way to preserve a multi-level table header —
+  at the cost of much less readable output.
+
+Run `marker_single --help` for the full flag list.
+
 ### Sidecar conversion report
 
 Every conversion writes a `<stem>.report.json` alongside the markdown
 containing: method used, page count, OCR pages, extracted assets,
-quality score, `cleaned`/`cleanup` stats, and any warnings. Useful for
-inspecting a batch run:
+quality score, `cleaned`/`cleanup` stats, table counts, and any warnings.
+Useful for inspecting a batch run:
 
 ```bash
 jq '.method,.extracted_assets,.quality_score' output/*.report.json
 ```
+
+**Table fidelity.** `table_captions_seen` counts `TABLE 9-1` style
+captions in the output; `tables_emitted` counts the grids actually
+produced. A wide gap means the captions survived but their grids
+collapsed into prose — the failure a three-page spot-check will miss.
+The report adds an explicit warning when captions outnumber grids.
+
+```bash
+jq '.tables_emitted, .table_captions_seen, .warnings' output/*.report.json
+```
+
+Note that the `ocr` (tesseract) backend has **no** table reconstruction
+at all, so it reports `0` emitted against however many captions it read.
+For a book with real tables, use `marker`.
 
 ### Archive source PDFs after conversion
 

--- a/convert.py
+++ b/convert.py
@@ -22,8 +22,10 @@ Usage:
 """
 
 import argparse
+import collections
 import logging
 import os
+import shlex
 import re
 import shutil
 import subprocess
@@ -1442,6 +1444,68 @@ def _words_to_text(words):
     return "\n".join(lines)
 
 
+# --- Table fidelity accounting ---------------------------------------------
+#
+# Independent of *how* a backend finds tables, we want a cheap post-hoc
+# answer to "did the grids survive?" Counting captions and emitted grids
+# separately gives that: a book with 47 "TABLE A-n" captions and 12
+# emitted grids lost 35 tables into prose, and the sidecar says so
+# without anyone reading 330 pages.
+
+# Matches a caption at the head of a line, with or without markdown bold:
+#   TABLE A-16 Mean Motive ...
+#   **TABLE 3.2.** Some Events ...
+#   EXHIBIT 5-1
+_TABLE_CAPTION_LINE_RE = re.compile(
+    r'^\s*\**\s*(?:TABLE|Table|TAB\.|Tab\.|EXHIBIT|Exhibit)\s+'
+    r'[A-Z]?-?\d+(?:[-.]\d+)?',
+    re.MULTILINE,
+)
+
+# A GFM table is identified by its separator row (|---|---|), which is the
+# one line every well-formed markdown table must have exactly once.
+_GFM_SEPARATOR_RE = re.compile(r'^\s*\|(?:\s*:?-+:?\s*\|)+\s*$', re.MULTILINE)
+
+# marker with --html_tables_in_markdown emits <table> instead of GFM.
+_HTML_TABLE_RE = re.compile(r'<table[\s>]', re.IGNORECASE)
+
+
+def count_table_signals(markdown_text):
+    """Return (tables_emitted, table_captions_seen) for a markdown body.
+
+    `tables_emitted` counts both GFM grids and raw HTML tables, so the
+    number stays comparable across renderer settings. Neither count is a
+    quality measure — a mangled grid still counts as emitted. The signal
+    is the *gap* between the two.
+    """
+    emitted = (
+        len(_GFM_SEPARATOR_RE.findall(markdown_text))
+        + len(_HTML_TABLE_RE.findall(markdown_text))
+    )
+    captions = len(_TABLE_CAPTION_LINE_RE.findall(markdown_text))
+    return emitted, captions
+
+
+def apply_table_signals(report, output_path):
+    """Populate a report's table counters by reading the emitted markdown.
+
+    Best-effort: a read failure leaves the counters at zero rather than
+    failing a conversion that otherwise succeeded.
+    """
+    try:
+        text = Path(output_path).read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        report.warnings.append(f"could not count tables: {e}")
+        return
+    report.tables_emitted, report.table_captions_seen = count_table_signals(text)
+    missing = report.table_captions_seen - report.tables_emitted
+    if missing > 0:
+        report.warnings.append(
+            f"{missing} table caption(s) have no emitted grid — "
+            f"those tables likely collapsed into prose"
+        )
+
+
 # --- Table detection and grid reconstruction -------------------------------
 #
 # Many books embed comparison tables with captions like "TABLE 9-1" followed
@@ -2344,10 +2408,13 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
     return report
 
 
-def convert_with_marker(pdf_path, output_dir):
+def convert_with_marker(pdf_path, output_dir, marker_args=None):
     """Convert a text-based PDF using Marker.
 
     Runs Marker in an isolated temp directory to avoid corrupting existing output.
+    `marker_args` is a list of extra flags forwarded verbatim to
+    `marker_single` (see `marker_single --help`) — this is how table-quality
+    flags like `--use_llm` and `--html_tables_in_markdown` are reached.
     Raises ConversionError on failure.
     """
     print(f"Converting with Marker: {pdf_path.name}")
@@ -2356,13 +2423,32 @@ def convert_with_marker(pdf_path, output_dir):
         # Newer marker-pdf releases (≥1.0) take the output path via the
         # `--output_dir` flag rather than as a second positional argument.
         # Passing it positionally raises "Got unexpected extra argument".
-        result = subprocess.run(
-            ["marker_single", str(pdf_path), "--output_dir", tmpdir],
-            capture_output=True,
+        cmd = ["marker_single", str(pdf_path), "--output_dir", tmpdir]
+        if marker_args:
+            cmd.extend(marker_args)
+            print(f"  extra marker args: {' '.join(marker_args)}")
+
+        # Stream marker's output rather than capturing it. A book-length
+        # scan is a 1+ hour run and marker's only progress signal is its
+        # per-stage progress bars on stderr; capture_output swallowed
+        # them entirely, so a backgrounded run looked identical to a hung
+        # one until it finished. We keep a rolling tail for the error
+        # message instead.
+        tail = collections.deque(maxlen=40)
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
+            bufsize=1,
         )
-        if result.returncode != 0:
-            raise ConversionError(f"Marker error: {result.stderr}")
+        for line in proc.stdout:
+            tail.append(line)
+            sys.stdout.write(line)
+            sys.stdout.flush()
+        returncode = proc.wait()
+        if returncode != 0:
+            raise ConversionError(f"Marker error: {''.join(tail)}")
 
         # Find the generated markdown in the temp directory
         tmp_path = Path(tmpdir)
@@ -2427,6 +2513,11 @@ def convert_with_marker(pdf_path, output_dir):
                 report.total_pages = len(src)
         except Exception as e:
             report.warnings.append(f"could not read page count: {e}")
+        apply_table_signals(report, target)
+        print(
+            f"  tables: {report.tables_emitted} emitted / "
+            f"{report.table_captions_seen} captions seen"
+        )
         report_path = target.with_suffix(".report.json")
         write_report(report_path, report)
         return report
@@ -2489,6 +2580,11 @@ def convert_with_ocr(pdf_path, output_dir):
     report.ocr_pages = total_pages
     extracted = output_file.read_text(encoding="utf-8", errors="replace")
     report.warnings.extend(_ocr_quality_warnings(extracted))
+    # The tesseract path has no table reconstruction at all, so this
+    # almost always reports "0 emitted / N captions". That is the point:
+    # it makes the OCR backend's table blindness visible in the sidecar
+    # instead of leaving it to be discovered during a scholarly pass.
+    apply_table_signals(report, output_file)
     report_path = output_file.with_suffix(".report.json")
     write_report(report_path, report)
     return report
@@ -2741,6 +2837,7 @@ def convert_with_docling(pdf_path, output_dir):
     return report
 
 
+
 def _apply_cleanup(result):
     """Run the post-conversion cleanup pass on a backend's markdown output.
 
@@ -2762,6 +2859,12 @@ def _apply_cleanup(result):
 
     result.cleaned = True
     result.cleanup = stats
+    # Cleanup can unwrap a picture-text table (a ToC rendered as a grid),
+    # which changes the table counts the backend recorded a moment ago.
+    # Recount against the post-cleanup text so the sidecar describes the
+    # file that actually landed on disk.
+    if cleaned != original:
+        result.tables_emitted, result.table_captions_seen = count_table_signals(cleaned)
     if not stats.get("dejoin_available"):
         result.warnings.append(
             "cleanup: de-join pass skipped (pyspellchecker not installed; "
@@ -2772,7 +2875,7 @@ def _apply_cleanup(result):
 
 
 def convert_book(book_path, output_dir, method="pymupdf", auto_ocr=False,
-                 extract_images=False, clean=True):
+                 extract_images=False, clean=True, marker_args=None):
     """Convert a single book (PDF or EPUB) to markdown.
 
     Returns True on success, False on failure. Never raises.
@@ -2783,6 +2886,8 @@ def convert_book(book_path, output_dir, method="pymupdf", auto_ocr=False,
     When clean is True (default), a verbatim-safe post-conversion pass repairs
     common extraction artifacts (dropped-space joins, stray-consonant citation
     ghosts, picture-text garble) on the emitted markdown.
+    `marker_args` is forwarded to the marker backend only; other backends
+    ignore it.
     """
     book_path = Path(book_path)
     output_dir = Path(output_dir)
@@ -2797,7 +2902,7 @@ def convert_book(book_path, output_dir, method="pymupdf", auto_ocr=False,
         if method == "ocr":
             result = convert_with_ocr(book_path, output_dir)
         elif method == "marker":
-            result = convert_with_marker(book_path, output_dir)
+            result = convert_with_marker(book_path, output_dir, marker_args=marker_args)
         elif method == "pymupdf4llm":
             result = convert_with_pymupdf4llm(book_path, output_dir)
         elif method == "docling":
@@ -2823,7 +2928,7 @@ def convert_book(book_path, output_dir, method="pymupdf", auto_ocr=False,
             try:
                 check_dependencies(chosen)
                 if chosen == "marker":
-                    result = convert_with_marker(book_path, output_dir)
+                    result = convert_with_marker(book_path, output_dir, marker_args=marker_args)
                 else:
                     result = convert_with_ocr(book_path, output_dir)
                 if clean:
@@ -2987,6 +3092,18 @@ def main():
              "the markdown (pymupdf backend only).",
     )
     parser.add_argument(
+        "--marker-args",
+        default="",
+        help="Extra flags forwarded verbatim to marker_single (marker backend "
+             "only). Quote the whole string, e.g. "
+             "--marker-args '--use_llm --html_tables_in_markdown'. Run "
+             "`marker_single --help` for the full list; the table-quality "
+             "flags are --use_llm (fixes merged headers and split rows, "
+             "needs an LLM service configured) and "
+             "--html_tables_in_markdown (preserves colspan/rowspan that GFM "
+             "cannot express).",
+    )
+    parser.add_argument(
         "--verbose", "-v",
         action="store_true",
         help="Enable verbose/debug logging output",
@@ -3027,6 +3144,11 @@ def main():
         method = "marker"
     else:
         method = args.method
+
+    # shlex so a quoted --marker-args string splits the way a shell would.
+    marker_args = shlex.split(args.marker_args) if args.marker_args else None
+    if marker_args and method != "marker":
+        print(f"Warning: --marker-args is ignored by the {method} backend")
 
     output_dir = Path(args.output)
     books = collect_books(args.input)
@@ -3070,6 +3192,7 @@ def main():
             auto_ocr=args.auto_ocr,
             extract_images=args.extract_images,
             clean=not args.no_clean,
+            marker_args=marker_args,
         ):
             success += 1
             converted_books.append(book)

--- a/report.py
+++ b/report.py
@@ -30,6 +30,13 @@ class ConversionReport:
     skipped_toc_pages: int = 0
     cleaned: bool = False
     cleanup: dict = field(default_factory=dict)
+    # Table fidelity signals. `table_captions_seen` counts "TABLE 9-1" /
+    # "EXHIBIT 3" style captions in the output text; `tables_emitted`
+    # counts grids the converter actually produced. A wide gap means the
+    # captions survived but their grids collapsed into prose — the
+    # failure mode a spot-check of three pages will not catch.
+    tables_emitted: int = 0
+    table_captions_seen: int = 0
     warnings: List[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -6,7 +6,9 @@ rebuild a proper grid from the dict-level line coordinates so markdown
 tables land in the output rather than a scrambled dump of cells.
 """
 import re
+
 import convert
+from report import ConversionReport
 
 
 # --- _cluster_1d ---
@@ -237,3 +239,59 @@ def test_extract_page_text_with_regions_matches_legacy_table_path(tmp_path):
         result = convert._extract_page_text_with_regions(page, regions)
     assert "Surrounding prose line" in result
     assert "| a | b |" in result
+
+
+# --- count_table_signals / apply_table_signals ---------------------------
+#
+# These back the `tables_emitted` / `table_captions_seen` sidecar fields.
+# The gap between the two is the only cheap signal that a book's grids
+# collapsed into prose, so the counts have to be right on real-world
+# caption shapes (bold, appendix letters, EXHIBIT) and must not be fooled
+# by prose that merely mentions a table.
+
+
+def test_count_table_signals_counts_gfm_grid_and_caption():
+    md = "TABLE A-16 Mean Motive Levels\n\n| a | b |\n|---|---|\n| 1 | 2 |\n"
+    assert convert.count_table_signals(md) == (1, 1)
+
+
+def test_count_table_signals_matches_bold_and_exhibit_captions():
+    md = "**TABLE 3.2.** Some Events\n\ntext\n\nEXHIBIT 5-1 Another\n"
+    emitted, captions = convert.count_table_signals(md)
+    assert captions == 2
+    assert emitted == 0
+
+
+def test_count_table_signals_counts_html_tables():
+    md = "TABLE 1 x\n\n<table><tbody><tr><td>a</td></tr></tbody></table>\n"
+    assert convert.count_table_signals(md) == (1, 1)
+
+
+def test_count_table_signals_ignores_prose_mentions_of_tables():
+    md = "As Table 3.2 shows, the effect held. See the table above.\n"
+    assert convert.count_table_signals(md) == (0, 0)
+
+
+def test_apply_table_signals_warns_when_captions_outnumber_grids(tmp_path):
+    """The collapsed-grid case: captions survive, grids don't."""
+    md = tmp_path / "out.md"
+    md.write_text("TABLE 1 a\n\nTABLE 2 b\n\n| x |\n|---|\n| 1 |\n", encoding="utf-8")
+    report = ConversionReport(source="s.pdf", output=str(md), method="marker")
+    convert.apply_table_signals(report, md)
+    assert (report.table_captions_seen, report.tables_emitted) == (2, 1)
+    assert any("collapsed into prose" in w for w in report.warnings)
+
+
+def test_apply_table_signals_silent_when_grids_match_captions(tmp_path):
+    md = tmp_path / "out.md"
+    md.write_text("TABLE 1 a\n\n| x |\n|---|\n| 1 |\n", encoding="utf-8")
+    report = ConversionReport(source="s.pdf", output=str(md), method="marker")
+    convert.apply_table_signals(report, md)
+    assert report.warnings == []
+
+
+def test_apply_table_signals_survives_unreadable_output(tmp_path):
+    report = ConversionReport(source="s.pdf", output="nope.md", method="marker")
+    convert.apply_table_signals(report, tmp_path / "does-not-exist.md")
+    assert report.tables_emitted == 0
+    assert any("could not count tables" in w for w in report.warnings)


### PR DESCRIPTION
Prompted by converting Boyatzis's *The Competent Manager* — a 330-page home scan whose value is largely in its statistical appendix tables. Investigating "will the tables survive?" turned up three gaps.

## What changed

**`--marker-args` passthrough.** `convert_with_marker` hardcoded `marker_single <pdf> --output_dir <tmp>`, so none of marker's table flags were reachable through the wrapper. Forwarded verbatim (shlex-split); other backends warn and ignore.

```bash
python convert.py input/Book.pdf --method marker --marker-args '--use_llm'
```

The two flags that matter for table-heavy books:
- `--use_llm` — activates `LLMTableProcessor` / `LLMTableMergeProcessor`, built for merged headers and rows split across lines. Needs a raw LLM API key (a Claude *subscription* does not authenticate the Anthropic API; marker's `ClaudeService` instantiates the SDK directly).
- `--html_tables_in_markdown` — emits real `colspan`/`rowspan`. GFM cannot express a spanning header cell at all.

**Streamed marker output.** The marker call used `subprocess.run(capture_output=True)`, which swallowed every progress bar. A book-length scan is a 1+ hour run, so a backgrounded conversion was indistinguishable from a hung one until it finished. Now streams via `Popen` with stderr merged, keeping a 40-line rolling tail for the error path.

**Table-fidelity counts.** New `tables_emitted` / `table_captions_seen` on the report. The *gap* between them is the only cheap signal that a book's grids collapsed into prose — invisible in a three-page spot-check. `apply_table_signals()` warns explicitly when captions outnumber grids.

```bash
jq '.tables_emitted, .table_captions_seen, .warnings' output/*.report.json
```

Wired into the marker and ocr backends. The tesseract path has no table reconstruction at all, so it reports `0` emitted against N captions — which is the point: it makes that blindness visible in the sidecar instead of during downstream research.

Counts are recomputed inside `_apply_cleanup` when the cleanup pass rewrites the markdown, since unwrapping a picture-text ToC changes the grid count.

## Evidence

On an 8-page calibration over the Boyatzis appendix, marker's OCR of table *cells* verified correct number-for-number against the page images. What breaks is (1) multi-level spanning headers — a format limitation, not an OCR failure; (2) line-wrapped row labels splitting into orphan rows; (3) occasional dropped cells and degenerate reads of faint rules. The counter reported 9 emitted / 9 captions on that range, correctly indicating all grids were present and the damage was *inside* them.

## Tests

7 new cases covering caption shapes (bold, appendix letters, `EXHIBIT`), HTML tables, prose mentions that must not count, the captions-outnumber-grids warning, and an unreadable output path.

`94 passed, 27 skipped` — all skips environmental (optional deps / Python version), pre-existing.

## Note

Branched off current `origin/main`, so this sits on top of the cleanup-pass merge (#20). Merge conflicts with that feature were resolved keeping both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)