### PR TITLE
Typed page locators: capture the printed page number instead of deleting it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ output/**/*.txt
 
 # Keep directory structure
 !.gitkeep
+
+# Subagent-driven-development scratch (ledger, briefs, review packages)
+.superpowers/

--- a/8-DECISIONS/2026-07-26-typed-page-locators.md
+++ b/8-DECISIONS/2026-07-26-typed-page-locators.md
@@ -64,10 +64,27 @@ other 94% safe rather than a guess.
   break. The known consumer is mc-wiki's `tools/wiki-maintain.py`. The 217
   already-converted vault files retain the old format until reconverted, so
   consumers must parse both formats during the transition.
-- `pandoc` (EPUB) and `marker` declare `locator_type: "none"` — always, with
-  no interpolation attempted. Sources ingested through them cannot be cited
-  by page — by design, because no page number exists to cite (EPUB has no
-  pages; `marker`'s own layout model doesn't currently expose one).
+- **Only `pymupdf` can produce a citable page number.** The full per-backend
+  capability map (`BACKEND_LOCATOR_TYPE`, `convert.py`) is:
+
+  | Backend | `locator_type` | Citable by page? |
+  |---|---|---|
+  | `pymupdf` | decided at runtime — `printed` if any folio was captured, else `sheet-only` | Yes, when `printed` |
+  | `pymupdf4llm` | `sheet-only` (fixed) | No |
+  | `ocr` | `sheet-only` (fixed) | No |
+  | `marker` | `none` (fixed) | No |
+  | `pandoc` | `none` (fixed) | No |
+  | `docling` | `none` (fixed) | No |
+
+  `pymupdf` is deliberately absent from `BACKEND_LOCATOR_TYPE` — it is the one
+  backend that decides its own `locator_type` at the end of a conversion, so
+  do not treat it as having a fixed value.
+
+  All three `none` backends — `marker`, `pandoc`, `docling` — declare
+  `locator_type: "none"` always, with no interpolation attempted. Sources
+  ingested through them cannot be cited by page: for `pandoc` because EPUB is
+  reflowable and no page number exists to cite; for `marker` and `docling`
+  because neither pipeline currently exposes a page address we can trust.
 
 ## Alternatives rejected
 

--- a/8-DECISIONS/2026-07-26-typed-page-locators.md
+++ b/8-DECISIONS/2026-07-26-typed-page-locators.md
@@ -1,0 +1,85 @@
+---
+type: decision
+date: 2026-07-26
+status: accepted
+tags: [conversion, citation, locators]
+---
+
+# Typed page locators: sheet index and printed folio are different things
+
+## Context
+
+BookConvert emitted `<!-- Page N -->` from three of six backends, where N was
+the PDF sheet index. Downstream, that was being read as a page number. It is
+not one. `_strip_running_headers()` was separately deleting the printed folio
+as noise, so the one citation-valid address was discarded on every conversion.
+
+## Decision
+
+Emit both addresses, and declare which exists:
+
+    <!-- Page sheet=59 folio=47 -->
+
+- `sheet` — PDF sheet index. Always accurate, sparse. For navigation.
+- `folio` — the number printed on the page. For citation. `none` when absent.
+
+The sidecar declares `locator_type` (`printed` | `sheet-only` | `none`) and
+`folio_coverage`. Every locator-emitting backend writes a sidecar, including
+backends that cannot produce folios at all — they say so explicitly rather
+than emitting nothing silently. `pandoc` (EPUB) is the clearest case: an EPUB
+is reflowable and has no pages to address, so `convert_with_pandoc` still
+writes a `.report.json` sidecar, declaring `locator_type: "none"`. Silence
+would be indistinguishable from a conversion that never ran; a sidecar that
+says "no locators exist" is a positive, checkable claim the ingestion gate can
+act on.
+
+Folios are interpolated across gaps only under three guards, together:
+
+1. **At least 3 captured arabic samples, all agreeing** on a constant
+   sheet→folio offset (`_derive_folio_offset`). Roman folios never
+   participate — they belong to a separate numbering sequence. Fewer than 3
+   samples, or any disagreement (e.g. a part-opener restarting at 1), and
+   `folio_offset_consistent` is `False`: no interpolation anywhere in the
+   book.
+2. **Clamped to the closed interval between the first and last captured
+   arabic sample** (`_arabic_folio_sheets` / `folio_span`). Interpolation
+   never extends past the last real observation — end matter or a second
+   numbering sequence past the final sample contributes no samples, so it
+   cannot disagree, and extrapolating there would invent confident wrong page
+   numbers a reader cannot detect.
+3. **Never below 1.** Even inside the clamped span, a derived candidate folio
+   less than 1 is discarded rather than emitted — pages that precede printed
+   page 1 stay `folio=none`.
+
+Andy ratified interpolation-with-guards over observed-folios-only on
+2026-07-26. The tradeoff is deliberate: captured folios are sparse (running
+headers/footers survive cleanup on only a fraction of pages — Grove's 319-page
+scan yielded ~20 readable folios), so observed-only would leave roughly 94% of
+a citable book uncitable. The three guards above are what make deriving the
+other 94% safe rather than a guess.
+
+## Consequences
+
+- **Breaking output-format change.** Consumers matching `<!-- Page (\d+) -->`
+  break. The known consumer is mc-wiki's `tools/wiki-maintain.py`. The 217
+  already-converted vault files retain the old format until reconverted, so
+  consumers must parse both formats during the transition.
+- `pandoc` (EPUB) and `marker` declare `locator_type: "none"` — always, with
+  no interpolation attempted. Sources ingested through them cannot be cited
+  by page — by design, because no page number exists to cite (EPUB has no
+  pages; `marker`'s own layout model doesn't currently expose one).
+
+## Alternatives rejected
+
+- **Keep `<!-- Page N -->` and document that it means sheet index.** Rejected:
+  the failure is silent and a reader cannot detect it. The whole point is to
+  make a sheet index unusable as a page number.
+- **Infer folios with a model.** Rejected: inventing a page number that is not
+  printed on the page is exactly the failure this prevents.
+- **Observed folios only, no interpolation.** Rejected: given how sparse
+  captured folios are in practice, this would leave the large majority of a
+  book uncitable by page even when the offset is provably constant. The three
+  guards (≥3 agreeing samples, clamped span, floor of 1) make derivation safe
+  enough to prefer over leaving nearly the whole book unaddressed.
+
+Full investigation: management-craft `docs/2B-PROJECTS/page-locator-pipeline/v1/RESEARCH.md`.

--- a/8-DECISIONS/2026-07-26-typed-page-locators.md
+++ b/8-DECISIONS/2026-07-26-typed-page-locators.md
@@ -5,58 +5,61 @@ status: accepted
 tags: [conversion, citation, locators]
 ---
 
-# Typed page locators: sheet index and printed folio are different things
+# Typed page locators: PDF page index and printed page number are different things
 
 ## Context
 
 BookConvert emitted `<!-- Page N -->` from three of six backends, where N was
-the PDF sheet index. Downstream, that was being read as a page number. It is
-not one. `_strip_running_headers()` was separately deleting the printed folio
-as noise, so the one citation-valid address was discarded on every conversion.
+the PDF page index. Downstream, that was being read as a page number. It is
+not one. `_strip_running_headers()` was separately deleting the printed page
+number as noise, so the one citation-valid address was discarded on every
+conversion.
 
 ## Decision
 
 Emit both addresses, and declare which exists:
 
-    <!-- Page sheet=59 folio=47 -->
+    <!-- page_pdf=59 page_printed=47 -->
 
-- `sheet` — PDF sheet index. Always accurate, sparse. For navigation.
-- `folio` — the number printed on the page. For citation. `none` when absent.
+- `page_pdf` — PDF page index. Always accurate, sparse. For navigation.
+- `page_printed` — the number printed on the page. For citation. `none` when
+  absent.
 
-The sidecar declares `locator_type` (`printed` | `sheet-only` | `none`) and
-`folio_coverage`. Every locator-emitting backend writes a sidecar, including
-backends that cannot produce folios at all — they say so explicitly rather
-than emitting nothing silently. `pandoc` (EPUB) is the clearest case: an EPUB
-is reflowable and has no pages to address, so `convert_with_pandoc` still
-writes a `.report.json` sidecar, declaring `locator_type: "none"`. Silence
-would be indistinguishable from a conversion that never ran; a sidecar that
-says "no locators exist" is a positive, checkable claim the ingestion gate can
-act on.
+The sidecar declares `page_numbering` (`printed` | `pdf_only` | `none`) and
+`page_printed_coverage`. Every locator-emitting backend writes a sidecar,
+including backends that cannot produce printed page numbers at all — they say
+so explicitly rather than emitting nothing silently. `pandoc` (EPUB) is the
+clearest case: an EPUB is reflowable and has no pages to address, so
+`convert_with_pandoc` still writes a `.report.json` sidecar, declaring
+`page_numbering: "none"`. Silence would be indistinguishable from a
+conversion that never ran; a sidecar that says "no locators exist" is a
+positive, checkable claim the ingestion gate can act on.
 
-Folios are interpolated across gaps only under three guards, together:
+Printed page numbers are interpolated across gaps only under three guards,
+together:
 
 1. **At least 3 captured arabic samples, all agreeing** on a constant
-   sheet→folio offset (`_derive_folio_offset`). Roman folios never
-   participate — they belong to a separate numbering sequence. Fewer than 3
-   samples, or any disagreement (e.g. a part-opener restarting at 1), and
-   `folio_offset_consistent` is `False`: no interpolation anywhere in the
-   book.
+   page_pdf→page_printed offset (`_derive_page_offset`). Roman page numbers
+   never participate — they belong to a separate numbering sequence. Fewer
+   than 3 samples, or any disagreement (e.g. a part-opener restarting at 1),
+   and `page_printed_offset_consistent` is `False`: no interpolation anywhere
+   in the book.
 2. **Clamped to the closed interval between the first and last captured
-   arabic sample** (`_arabic_folio_sheets` / `folio_span`). Interpolation
-   never extends past the last real observation — end matter or a second
-   numbering sequence past the final sample contributes no samples, so it
-   cannot disagree, and extrapolating there would invent confident wrong page
-   numbers a reader cannot detect.
-3. **Never below 1.** Even inside the clamped span, a derived candidate folio
-   less than 1 is discarded rather than emitted — pages that precede printed
-   page 1 stay `folio=none`.
+   arabic sample** (`_arabic_page_pdf_indices` / `page_pdf_span`).
+   Interpolation never extends past the last real observation — end matter or
+   a second numbering sequence past the final sample contributes no samples,
+   so it cannot disagree, and extrapolating there would invent confident
+   wrong page numbers a reader cannot detect.
+3. **Never below 1.** Even inside the clamped span, a derived candidate
+   printed page number less than 1 is discarded rather than emitted — pages
+   that precede printed page 1 stay `page_printed=none`.
 
-Andy ratified interpolation-with-guards over observed-folios-only on
-2026-07-26. The tradeoff is deliberate: captured folios are sparse (running
-headers/footers survive cleanup on only a fraction of pages — Grove's 319-page
-scan yielded ~20 readable folios), so observed-only would leave roughly 94% of
-a citable book uncitable. The three guards above are what make deriving the
-other 94% safe rather than a guess.
+Andy ratified interpolation-with-guards over observed-page-numbers-only on
+2026-07-26. The tradeoff is deliberate: captured printed page numbers are
+sparse (running headers/footers survive cleanup on only a fraction of pages —
+Grove's 319-page scan yielded ~20 readable printed page numbers), so
+observed-only would leave roughly 94% of a citable book uncitable. The three
+guards above are what make deriving the other 94% safe rather than a guess.
 
 ## Consequences
 
@@ -65,38 +68,40 @@ other 94% safe rather than a guess.
   already-converted vault files retain the old format until reconverted, so
   consumers must parse both formats during the transition.
 - **Only `pymupdf` can produce a citable page number.** The full per-backend
-  capability map (`BACKEND_LOCATOR_TYPE`, `convert.py`) is:
+  capability map (`BACKEND_PAGE_NUMBERING`, `convert.py`) is:
 
-  | Backend | `locator_type` | Citable by page? |
+  | Backend | `page_numbering` | Citable by page? |
   |---|---|---|
-  | `pymupdf` | decided at runtime — `printed` if any folio was captured, else `sheet-only` | Yes, when `printed` |
-  | `pymupdf4llm` | `sheet-only` (fixed) | No |
-  | `ocr` | `sheet-only` (fixed) | No |
+  | `pymupdf` | decided at runtime — `printed` if any printed page number was captured, else `pdf_only` | Yes, when `printed` |
+  | `pymupdf4llm` | `pdf_only` (fixed) | No |
+  | `ocr` | `pdf_only` (fixed) | No |
   | `marker` | `none` (fixed) | No |
   | `pandoc` | `none` (fixed) | No |
   | `docling` | `none` (fixed) | No |
 
-  `pymupdf` is deliberately absent from `BACKEND_LOCATOR_TYPE` — it is the one
-  backend that decides its own `locator_type` at the end of a conversion, so
-  do not treat it as having a fixed value.
+  `pymupdf` is deliberately absent from `BACKEND_PAGE_NUMBERING` — it is the
+  one backend that decides its own `page_numbering` at the end of a
+  conversion, so do not treat it as having a fixed value.
 
   All three `none` backends — `marker`, `pandoc`, `docling` — declare
-  `locator_type: "none"` always, with no interpolation attempted. Sources
+  `page_numbering: "none"` always, with no interpolation attempted. Sources
   ingested through them cannot be cited by page: for `pandoc` because EPUB is
   reflowable and no page number exists to cite; for `marker` and `docling`
   because neither pipeline currently exposes a page address we can trust.
 
 ## Alternatives rejected
 
-- **Keep `<!-- Page N -->` and document that it means sheet index.** Rejected:
-  the failure is silent and a reader cannot detect it. The whole point is to
-  make a sheet index unusable as a page number.
-- **Infer folios with a model.** Rejected: inventing a page number that is not
-  printed on the page is exactly the failure this prevents.
-- **Observed folios only, no interpolation.** Rejected: given how sparse
-  captured folios are in practice, this would leave the large majority of a
-  book uncitable by page even when the offset is provably constant. The three
-  guards (≥3 agreeing samples, clamped span, floor of 1) make derivation safe
-  enough to prefer over leaving nearly the whole book unaddressed.
+- **Keep `<!-- Page N -->` and document that it means PDF page index.**
+  Rejected: the failure is silent and a reader cannot detect it. The whole
+  point is to make a PDF page index unusable as a page number.
+- **Infer printed page numbers with a model.** Rejected: inventing a page
+  number that is not printed on the page is exactly the failure this
+  prevents.
+- **Observed printed page numbers only, no interpolation.** Rejected: given
+  how sparse captured printed page numbers are in practice, this would leave
+  the large majority of a book uncitable by page even when the offset is
+  provably constant. The three guards (≥3 agreeing samples, clamped span,
+  floor of 1) make derivation safe enough to prefer over leaving nearly the
+  whole book unaddressed.
 
 Full investigation: management-craft `docs/2B-PROJECTS/page-locator-pipeline/v1/RESEARCH.md`.

--- a/README.md
+++ b/README.md
@@ -110,11 +110,16 @@ for EPUB.
 Never present a `sheet` value as a page number. The sidecar declares which
 you have:
 
-| `locator_type` | Meaning |
-|---|---|
-| `printed` | Real page numbers were captured |
-| `sheet-only` | PDF sheet index only |
-| `none` | No locators emitted at all |
+| `locator_type` | Meaning | Backends |
+|---|---|---|
+| `printed` | Real page numbers were captured | `pymupdf`, when folios were actually found |
+| `sheet-only` | PDF sheet index only | `pymupdf` (no folios found), `pymupdf4llm`, `ocr` |
+| `none` | No locators emitted at all | `marker`, `pandoc` (EPUB), `docling` |
+
+`pymupdf` is the only backend that can produce a citable page number, and it
+decides between `printed` and `sheet-only` at runtime. The other five have a
+fixed capability. Read `locator_type` from the sidecar rather than assuming it
+from the `--method` you asked for.
 
 Where folio survival is sparse, `folio_offset` is derived from the captured
 samples and used to fill the gaps — but only when at least 3 arabic samples

--- a/README.md
+++ b/README.md
@@ -92,6 +92,42 @@ diagrams, and embedded raster images as PNGs in a sibling directory
 (`output/<stem>_assets/`) and inserts markdown image references into
 the body text at the right page position.
 
+### Page locators
+
+Every locator-emitting backend writes one comment per page:
+
+    <!-- Page sheet=59 folio=47 -->
+    <!-- Page sheet=3 folio=none -->
+
+`sheet` is the 1-based index of the page inside the PDF file. It is always
+accurate, and is sparse — pages with no extractable text are omitted.
+
+`folio` is the page number **printed on the page**. It is the only address
+valid for scholarly citation. It is `none` when the source carries no
+printed page number, which is normal for ebook-derived PDFs and universal
+for EPUB.
+
+Never present a `sheet` value as a page number. The sidecar declares which
+you have:
+
+| `locator_type` | Meaning |
+|---|---|
+| `printed` | Real page numbers were captured |
+| `sheet-only` | PDF sheet index only |
+| `none` | No locators emitted at all |
+
+Where folio survival is sparse, `folio_offset` is derived from the captured
+samples and used to fill the gaps — but only when at least 3 arabic samples
+all agree (`folio_offset_consistent: true`), and only for sheets that fall
+between the first and last captured sample. A book that renumbers partway
+through, or that has printed folios only in part of the text, gets no
+interpolation (or interpolation clamped to that span) rather than invented
+page numbers — and interpolation never produces a folio below 1.
+
+Check coverage after any conversion:
+
+    jq '.locator_type, .folio_coverage, .folio_offset_consistent' output/<Title>.report.json
+
 ### Post-conversion cleanup (on by default)
 
 Every conversion runs a verbatim-safe cleanup pass over the emitted

--- a/README.md
+++ b/README.md
@@ -96,42 +96,45 @@ the body text at the right page position.
 
 Every locator-emitting backend writes one comment per page:
 
-    <!-- Page sheet=59 folio=47 -->
-    <!-- Page sheet=3 folio=none -->
+    <!-- page_pdf=59 page_printed=47 -->
+    <!-- page_pdf=3 page_printed=none -->
 
-`sheet` is the 1-based index of the page inside the PDF file. It is always
-accurate, and is sparse — pages with no extractable text are omitted.
+`page_pdf` is the 1-based index of the page inside the PDF file. It is
+always accurate, and is sparse — pages with no extractable text are
+omitted.
 
-`folio` is the page number **printed on the page**. It is the only address
-valid for scholarly citation. It is `none` when the source carries no
-printed page number, which is normal for ebook-derived PDFs and universal
-for EPUB.
+`page_printed` is the page number **printed on the page**. It is the only
+address valid for scholarly citation. It is `none` when the source carries
+no printed page number, which is normal for ebook-derived PDFs and
+universal for EPUB.
 
-Never present a `sheet` value as a page number. The sidecar declares which
-you have:
+Never present a `page_pdf` value as a page number. The sidecar declares
+which you have:
 
-| `locator_type` | Meaning | Backends |
+| `page_numbering` | Meaning | Backends |
 |---|---|---|
-| `printed` | Real page numbers were captured | `pymupdf`, when folios were actually found |
-| `sheet-only` | PDF sheet index only | `pymupdf` (no folios found), `pymupdf4llm`, `ocr` |
+| `printed` | Real page numbers were captured | `pymupdf`, when printed page numbers were actually found |
+| `pdf_only` | PDF page index only | `pymupdf` (no printed page numbers found), `pymupdf4llm`, `ocr` |
 | `none` | No locators emitted at all | `marker`, `pandoc` (EPUB), `docling` |
 
 `pymupdf` is the only backend that can produce a citable page number, and it
-decides between `printed` and `sheet-only` at runtime. The other five have a
-fixed capability. Read `locator_type` from the sidecar rather than assuming it
-from the `--method` you asked for.
+decides between `printed` and `pdf_only` at runtime. The other five have a
+fixed capability. Read `page_numbering` from the sidecar rather than
+assuming it from the `--method` you asked for.
 
-Where folio survival is sparse, `folio_offset` is derived from the captured
-samples and used to fill the gaps — but only when at least 3 arabic samples
-all agree (`folio_offset_consistent: true`), and only for sheets that fall
+Where printed-page-number survival is sparse, `page_printed_offset` is
+derived from the captured samples and used to fill the gaps — but only
+when at least 3 arabic samples all agree
+(`page_printed_offset_consistent: true`), and only for PDF pages that fall
 between the first and last captured sample. A book that renumbers partway
-through, or that has printed folios only in part of the text, gets no
+through, or that has printed page numbers only in part of the text, gets no
 interpolation (or interpolation clamped to that span) rather than invented
-page numbers — and interpolation never produces a folio below 1.
+page numbers — and interpolation never produces a printed page number
+below 1.
 
 Check coverage after any conversion:
 
-    jq '.locator_type, .folio_coverage, .folio_offset_consistent' output/<Title>.report.json
+    jq '.page_numbering, .page_printed_coverage, .page_printed_offset_consistent' output/<Title>.report.json
 
 ### Post-conversion cleanup (on by default)
 

--- a/convert.py
+++ b/convert.py
@@ -873,6 +873,31 @@ def _derive_folio_offset(folio_by_sheet):
     return (None, False)
 
 
+# What kind of page address each backend can produce. `pymupdf` is absent
+# because it decides at runtime (printed when folios were captured,
+# sheet-only otherwise) — see convert_with_pymupdf.
+BACKEND_LOCATOR_TYPE = {
+    "ocr": "sheet-only",
+    "pymupdf4llm": "sheet-only",
+    "marker": "none",
+    "pandoc": "none",
+    "docling": "none",
+}
+
+
+def _apply_backend_locator_type(report):
+    """Stamp a backend's fixed locator capability onto its report.
+
+    Backends that cannot produce a printed page number must declare it, so
+    the ingestion gate can route away from them instead of silently filing
+    a source that can never be cited by page.
+    """
+    fixed = BACKEND_LOCATOR_TYPE.get(report.method)
+    if fixed:
+        report.locator_type = fixed
+    return report
+
+
 def _merge_split_caps_headings(lines):
     """Merge runs of consecutive short ALL-CAPS lines into single heading lines.
 
@@ -2622,6 +2647,7 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None):
             f"  tables: {report.tables_emitted} emitted / "
             f"{report.table_captions_seen} captions seen"
         )
+        _apply_backend_locator_type(report)
         report_path = target.with_suffix(".report.json")
         write_report(report_path, report)
         return report
@@ -2669,7 +2695,7 @@ def convert_with_ocr(pdf_path, output_dir):
                 text = pytesseract.image_to_string(images[0])
                 if text.strip():
                     pages_with_text += 1
-                    f.write(f"<!-- Page {i} -->\n\n")
+                    f.write(f"<!-- Page sheet={i} folio=none -->\n\n")
                     cleaned = clean_text(text.strip())
                     cleaned = _format_headings(cleaned)
                     cleaned = _format_toc(cleaned)
@@ -2689,6 +2715,7 @@ def convert_with_ocr(pdf_path, output_dir):
     # it makes the OCR backend's table blindness visible in the sidecar
     # instead of leaving it to be discovered during a scholarly pass.
     apply_table_signals(report, output_file)
+    _apply_backend_locator_type(report)
     report_path = output_file.with_suffix(".report.json")
     write_report(report_path, report)
     return report
@@ -2827,10 +2854,9 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
 
     # pymupdf4llm returns the full markdown as a string by default, OR
     # a list of per-page dicts when page_chunks=True. We use page_chunks
-    # so we can emit the same `<!-- Page N -->` markers BookConvert's
-    # default pymupdf backend produces, downstream tools (Management
-    # Craft's VKM extraction pipeline) rely on those markers to derive
-    # citation addresses.
+    # so we can emit page markers between chunks. Markers use the shared
+    # sheet/folio locator format; pymupdf4llm returns pre-cleaned text, so
+    # no printed folio is recoverable here.
     # pymupdf4llm sanitizes spaces in image_path to underscores when it
     # writes the PNGs, so we must sanitize the directory name ourselves
     # before mkdir — otherwise we'd create "Stem With Spaces_images/" and
@@ -2847,8 +2873,8 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
         page_chunks=True,
     )
 
-    # Stitch chunks with `<!-- Page N -->` markers between them.
-    # pymupdf4llm's metadata.page_number is already 1-indexed (matches the
+    # Stitch chunks with `<!-- Page sheet={N} folio=none -->` markers between
+    # them. pymupdf4llm's metadata.page_number is already 1-indexed (matches the
     # pymupdf backend's convention at line ~2280 above). Use it directly;
     # fall back to a 1-based enumeration if the key is missing for some
     # malformed PDF.
@@ -2856,7 +2882,7 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
     for idx, chunk in enumerate(page_chunks, start=1):
         page_num = chunk.get("metadata", {}).get("page_number", idx)
         chunk_text = chunk.get("text", "")
-        body_parts.append(f"<!-- Page {page_num} -->\n\n{chunk_text}")
+        body_parts.append(f"<!-- Page sheet={page_num} folio=none -->\n\n{chunk_text}")
     markdown = "\n\n".join(body_parts)
 
     # pymupdf4llm embeds the full `image_path` we passed as the literal ref
@@ -2894,6 +2920,7 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
         pages_with_text=total_pages,  # pymupdf4llm handles its own detection
         extracted_assets=extracted_assets,
     )
+    _apply_backend_locator_type(report)
     write_report(output_file.with_suffix(".report.json"), report)
     return report
 
@@ -2937,6 +2964,7 @@ def convert_with_docling(pdf_path, output_dir):
         total_pages=total_pages,
         pages_with_text=total_pages,
     )
+    _apply_backend_locator_type(report)
     write_report(output_file.with_suffix(".report.json"), report)
     return report
 

--- a/convert.py
+++ b/convert.py
@@ -2301,8 +2301,10 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
 
     doc.close()
 
-    # Strip running headers/footers across all pages
+    # Strip running headers/footers across all pages, capturing the printed
+    # folio (the only citation-valid address) as we go.
     cleaned_pages = _strip_running_headers(raw_pages)
+    folio_by_sheet = {sheet: folio for sheet, _, folio in cleaned_pages if folio}
 
     skipped_toc_pages = 0
 
@@ -2331,7 +2333,7 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
         # content the user needs for keyword lookup.
         toc_skip_cutoff = max(20, total_pages // 10)
 
-        for page_num, text in cleaned_pages:
+        for page_num, text, folio in cleaned_pages:
             # Detect index/glossary-style list pages so we can preserve
             # newlines instead of collapsing every entry into one paragraph.
             # Skip this in the front matter so _format_toc + broken-TOC
@@ -2359,12 +2361,20 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
                 skipped_toc_pages += 1
                 log.debug("Skipping broken TOC page %d", page_num)
                 continue
-            f.write(f"<!-- Page {page_num} -->\n\n")
+            f.write(f"<!-- Page sheet={page_num} folio={folio or 'none'} -->\n\n")
             f.write(cleaned)
             f.write("\n\n")
 
     if skipped_toc_pages:
         print(f"  Replaced {skipped_toc_pages} broken TOC page(s) with embedded bookmark TOC")
+
+    report.total_locator_pages = len(cleaned_pages)
+    report.folio_pages = len(folio_by_sheet)
+    report.folio_coverage = (
+        report.folio_pages / report.total_locator_pages
+        if report.total_locator_pages else 0.0
+    )
+    report.locator_type = "printed" if report.folio_pages else "sheet-only"
 
     # Check if we got enough text to consider this a real conversion
     if total_pages > 0 and (pages_with_text / total_pages) < MIN_TEXT_RATIO:

--- a/convert.py
+++ b/convert.py
@@ -817,6 +817,35 @@ def _strip_running_headers(pages_text):
     return result
 
 
+def _derive_folio_offset(folio_by_sheet):
+    """Derive a constant sheet->folio offset from captured samples.
+
+    Returns (offset, is_consistent). `offset` is folio - sheet. Consistency
+    requires at least 3 arabic samples that all agree; a book that renumbers
+    partway through (part-openers restarting at 1, roman-to-arabic front
+    matter) will disagree, and we refuse to interpolate rather than invent
+    page numbers. Roman folios never participate — they belong to a
+    separate numbering sequence.
+
+    Args:
+        folio_by_sheet: dict of sheet index -> folio string
+
+    Returns:
+        (int | None, bool)
+    """
+    offsets = [
+        int(folio) - sheet
+        for sheet, folio in folio_by_sheet.items()
+        if folio.isdigit()
+    ]
+    if len(offsets) < 3:
+        return (None, False)
+    first = offsets[0]
+    if all(o == first for o in offsets):
+        return (first, True)
+    return (None, False)
+
+
 def _merge_split_caps_headings(lines):
     """Merge runs of consecutive short ALL-CAPS lines into single heading lines.
 
@@ -2305,6 +2334,7 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
     # folio (the only citation-valid address) as we go.
     cleaned_pages = _strip_running_headers(raw_pages)
     folio_by_sheet = {sheet: folio for sheet, _, folio in cleaned_pages if folio}
+    folio_offset, folio_consistent = _derive_folio_offset(folio_by_sheet)
 
     skipped_toc_pages = 0
 
@@ -2361,7 +2391,13 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
                 skipped_toc_pages += 1
                 log.debug("Skipping broken TOC page %d", page_num)
                 continue
-            f.write(f"<!-- Page sheet={page_num} folio={folio or 'none'} -->\n\n")
+            effective_folio = folio
+            if effective_folio is None and folio_consistent:
+                candidate = page_num + folio_offset
+                # Never invent a folio for pages that precede printed page 1.
+                if candidate >= 1:
+                    effective_folio = str(candidate)
+            f.write(f"<!-- Page sheet={page_num} folio={effective_folio or 'none'} -->\n\n")
             f.write(cleaned)
             f.write("\n\n")
 
@@ -2375,6 +2411,8 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
         if report.total_locator_pages else 0.0
     )
     report.locator_type = "printed" if report.folio_pages else "sheet-only"
+    report.folio_offset = folio_offset
+    report.folio_offset_consistent = folio_consistent
 
     # Check if we got enough text to consider this a real conversion
     if total_pages > 0 and (pages_with_text / total_pages) < MIN_TEXT_RATIO:

--- a/convert.py
+++ b/convert.py
@@ -652,6 +652,24 @@ def _strip_running_headers(pages_text):
         list of (page_num, cleaned_text, folio) tuples, where folio is the
         printed page number captured from the running header/footer as a
         string ("47", "xii"), or None when the page carries none.
+
+    Stripping and capture are deliberately separate concerns. What gets
+    removed from the body text is unchanged from the pre-folio behavior;
+    what we are willing to *believe* is a printed page number is a strictly
+    narrower set. A folio we emit is presented to a reader as the number
+    printed on that page, so a wrong one is worse than none at all.
+
+    Folio candidates are collected as (rank, value) and the lowest rank
+    wins:
+
+        rank 0 — a standalone number on its own line near the page bottom
+        rank 1 — a standalone number on its own line near the page top
+
+    There is deliberately no rank for "a number trailing the last line of
+    body text". Such a number is still stripped (it is usually a footer
+    that extraction glued onto the preceding line), but it is never
+    captured: a page whose last sentence legitimately ends in a year would
+    otherwise publish "1999" as its printed page number.
     """
     if len(pages_text) < 5:
         return [(page_num, text, None) for page_num, text in pages_text]
@@ -730,7 +748,12 @@ def _strip_running_headers(pages_text):
     # Also detect standalone page-number lines (just a number, maybe with spaces)
     # Always strip these, even if no header/footer patterns were found
     standalone_pagenum = re.compile(r'^\s*\d{1,4}\s*$')
-    # Also match standalone roman numeral page numbers (front matter)
+    # Also match standalone roman numeral page numbers (front matter).
+    # NOTE: this is the STRIPPING test only, and it is intentionally loose
+    # (a bag of roman letters). Loosening or tightening it changes what
+    # disappears from the body text across every already-converted book.
+    # Whether a stripped line is believed to BE a folio is decided
+    # separately, by _is_roman_folio + the two-sample confirmation below.
     roman_pagenum = re.compile(
         r'^\s*[ivxlc]{1,7}\s*$', re.I
     )
@@ -782,10 +805,18 @@ def _strip_running_headers(pages_text):
             # Capture-then-strip standalone page numbers (arabic or roman).
             # This is the printed folio — the only address that is valid for
             # citation. It used to be discarded here.
+            #
+            # The strip condition is unchanged. The capture condition is
+            # narrower: an arabic run is taken at face value, but a roman
+            # line must parse as a real roman numeral (so "ill" and "civil"
+            # are stripped as before and captured never).
             if (is_near_top or is_near_bottom) and (
                 standalone_pagenum.match(stripped) or roman_pagenum.match(stripped)
             ):
-                folio_candidates.append((0 if is_near_bottom else 1, stripped))
+                if standalone_pagenum.match(stripped):
+                    folio_candidates.append((0 if is_near_bottom else 1, stripped))
+                elif _is_roman_folio(stripped.strip()):
+                    folio_candidates.append((0 if is_near_bottom else 1, stripped))
                 continue
 
             # Strip "CHAPTER TITLE | page" or "page | BOOK TITLE" running headers
@@ -796,25 +827,73 @@ def _strip_running_headers(pages_text):
                 log.debug("  Stripping pipe header/footer on page %d: %r", page_num, stripped)
                 continue
 
-            # Strip trailing page number appended to last line, capturing it
-            # as a last-resort folio candidate.
+            # Strip a trailing page number appended to the last line. This
+            # is a stripping rule ONLY — see the docstring. The number is
+            # NOT a folio candidate: the last line of a page legitimately
+            # ends in a number often enough ("...published in 1999") that
+            # capturing here publishes numbers that were never printed,
+            # poisons the offset derivation, and inflates folio_pages.
             if is_last:
                 m_trail = re.search(r'\s+(\d{1,4})\s*$', line)
                 if m_trail:
-                    folio_candidates.append((2, m_trail.group(1)))
                     line = line[:m_trail.start()]
 
             cleaned.append(line)
+        result.append((page_num, '\n'.join(cleaned), folio_candidates))
+
+    # Roman folios need corroboration. Real front matter runs several
+    # numbered pages, so >= 2 distinct roman captures across the document
+    # is cheap evidence that we are looking at a numbering sequence. A lone
+    # "I" or "Li" is far more likely to be English prose that survived as
+    # its own line, and emitting it would flip locator_type to "printed" on
+    # a book that has no printed folios at all.
+    roman_values = {
+        value for _, _, cands in result
+        for _, value in cands
+        if not standalone_pagenum.match(value)
+    }
+    romans_confirmed = len(roman_values) >= 2
+    if roman_values and not romans_confirmed:
+        log.debug("Discarding %d unconfirmed roman folio capture(s): %r",
+                  len(roman_values), sorted(roman_values))
+
+    finalized = []
+    for page_num, cleaned_text, cands in result:
+        if not romans_confirmed:
+            cands = [c for c in cands if standalone_pagenum.match(c[1])]
         # Key on rank only: min() is stable, so equal ranks resolve to the
         # first candidate encountered. Comparing whole tuples would break
         # ties lexicographically by value ("12" < "47"), which is wrong.
-        folio = (
-            min(folio_candidates, key=lambda c: c[0])[1]
-            if folio_candidates else None
-        )
-        result.append((page_num, '\n'.join(cleaned), folio))
+        folio = min(cands, key=lambda c: c[0])[1] if cands else None
+        finalized.append((page_num, cleaned_text, folio))
 
-    return result
+    return finalized
+
+
+# Real roman-numeral grammar, not a bag of roman letters. The lookahead
+# rejects the empty match that every group-optional alternative allows.
+# This is what separates "xii" (a folio) from "ill" and "civil" (English
+# words that the loose stripping regex also matches).
+_ROMAN_FOLIO_RE = re.compile(
+    r'^(?=[ivxlcdm])m{0,4}(?:cm|cd|d?c{0,3})(?:xc|xl|l?x{0,3})(?:ix|iv|v?i{0,3})$',
+    re.I,
+)
+
+
+def _is_roman_folio(folio):
+    """True only for a well-formed roman numeral like "xii".
+
+    The stripping regex is a letter-bag (`[ivxlc]{1,7}`) that also matches
+    English words — "I", "ill", "civil", "Li", "lix". Stripping those was
+    harmless; emitting them as printed page numbers is not, so capture
+    validates against the actual grammar.
+
+    Grammar alone still admits "I" (a legitimate roman 1, and also the
+    English pronoun). That residual ambiguity is resolved separately, by
+    requiring at least two distinct roman captures in the document before
+    any of them counts.
+    """
+    return bool(folio) and bool(_ROMAN_FOLIO_RE.match(folio))
 
 
 def _is_arabic_folio(folio):
@@ -2398,6 +2477,11 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
     )
 
     skipped_toc_pages = 0
+    # Counts pages that actually emitted a locator comment. `cleaned_pages`
+    # is the wrong denominator: blank pages and replaced TOC pages are
+    # `continue`d below and never get a locator, so dividing by it reports
+    # a folio_coverage lower than the real one.
+    emitted_locator_pages = 0
 
     # errors="replace" is a safety net for any surrogate chars that slip
     # through the explicit _strip_surrogates() calls above
@@ -2462,13 +2546,14 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
                 if candidate >= 1:
                     effective_folio = str(candidate)
             f.write(f"<!-- Page sheet={page_num} folio={effective_folio or 'none'} -->\n\n")
+            emitted_locator_pages += 1
             f.write(cleaned)
             f.write("\n\n")
 
     if skipped_toc_pages:
         print(f"  Replaced {skipped_toc_pages} broken TOC page(s) with embedded bookmark TOC")
 
-    report.total_locator_pages = len(cleaned_pages)
+    report.total_locator_pages = emitted_locator_pages
     report.folio_pages = len(folio_by_sheet)
     report.folio_coverage = (
         report.folio_pages / report.total_locator_pages

--- a/convert.py
+++ b/convert.py
@@ -649,10 +649,12 @@ def _strip_running_headers(pages_text):
         pages_text: list of (page_num, raw_text) tuples
 
     Returns:
-        list of (page_num, cleaned_text) tuples
+        list of (page_num, cleaned_text, folio) tuples, where folio is the
+        printed page number captured from the running header/footer as a
+        string ("47", "xii"), or None when the page carries none.
     """
     if len(pages_text) < 5:
-        return pages_text
+        return [(page_num, text, None) for page_num, text in pages_text]
 
     # Collect the first few and last few lines from each page
     # to detect running headers/footers regardless of position
@@ -737,6 +739,7 @@ def _strip_running_headers(pages_text):
     for page_num, text in pages_text:
         lines = text.split('\n')
         cleaned = []
+        folio_candidates = []   # (rank, value)
         for j, line in enumerate(lines):
             stripped = line.strip()
             if not stripped:
@@ -776,10 +779,13 @@ def _strip_running_headers(pages_text):
                         log.debug("  Stripped inline header on page %d: prefix=%r", page_num, prefix)
                         break
 
-            # Strip standalone page numbers (arabic or roman) at start/end of page
+            # Capture-then-strip standalone page numbers (arabic or roman).
+            # This is the printed folio — the only address that is valid for
+            # citation. It used to be discarded here.
             if (is_near_top or is_near_bottom) and (
                 standalone_pagenum.match(stripped) or roman_pagenum.match(stripped)
             ):
+                folio_candidates.append((0 if is_near_bottom else 1, stripped))
                 continue
 
             # Strip "CHAPTER TITLE | page" or "page | BOOK TITLE" running headers
@@ -790,12 +796,23 @@ def _strip_running_headers(pages_text):
                 log.debug("  Stripping pipe header/footer on page %d: %r", page_num, stripped)
                 continue
 
-            # Strip trailing page number appended to last line
+            # Strip trailing page number appended to last line, capturing it
+            # as a last-resort folio candidate.
             if is_last:
-                line = re.sub(r'\s+\d{1,4}\s*$', '', line)
+                m_trail = re.search(r'\s+(\d{1,4})\s*$', line)
+                if m_trail:
+                    folio_candidates.append((2, m_trail.group(1)))
+                    line = line[:m_trail.start()]
 
             cleaned.append(line)
-        result.append((page_num, '\n'.join(cleaned)))
+        # Key on rank only: min() is stable, so equal ranks resolve to the
+        # first candidate encountered. Comparing whole tuples would break
+        # ties lexicographically by value ("12" < "47"), which is wrong.
+        folio = (
+            min(folio_candidates, key=lambda c: c[0])[1]
+            if folio_candidates else None
+        )
+        result.append((page_num, '\n'.join(cleaned), folio))
 
     return result
 

--- a/convert.py
+++ b/convert.py
@@ -649,18 +649,20 @@ def _strip_running_headers(pages_text):
         pages_text: list of (page_num, raw_text) tuples
 
     Returns:
-        list of (page_num, cleaned_text, folio) tuples, where folio is the
-        printed page number captured from the running header/footer as a
-        string ("47", "xii"), or None when the page carries none.
+        list of (page_num, cleaned_text, page_printed) tuples, where
+        page_printed is the printed page number captured from the running
+        header/footer as a string ("47", "xii"), or None when the page
+        carries none.
 
     Stripping and capture are deliberately separate concerns. What gets
-    removed from the body text is unchanged from the pre-folio behavior;
-    what we are willing to *believe* is a printed page number is a strictly
-    narrower set. A folio we emit is presented to a reader as the number
-    printed on that page, so a wrong one is worse than none at all.
+    removed from the body text is unchanged from the pre-page_printed
+    behavior; what we are willing to *believe* is a printed page number is
+    a strictly narrower set. A page_printed value we emit is presented to
+    a reader as the number printed on that page, so a wrong one is worse
+    than none at all.
 
-    Folio candidates are collected as (rank, value) and the lowest rank
-    wins:
+    Page-printed candidates are collected as (rank, value) and the lowest
+    rank wins:
 
         rank 0 — a standalone number on its own line near the page bottom
         rank 1 — a standalone number on its own line near the page top
@@ -752,8 +754,9 @@ def _strip_running_headers(pages_text):
     # NOTE: this is the STRIPPING test only, and it is intentionally loose
     # (a bag of roman letters). Loosening or tightening it changes what
     # disappears from the body text across every already-converted book.
-    # Whether a stripped line is believed to BE a folio is decided
-    # separately, by _is_roman_folio + the two-sample confirmation below.
+    # Whether a stripped line is believed to BE a printed page number is
+    # decided separately, by _is_roman_page_number + the two-sample
+    # confirmation below.
     roman_pagenum = re.compile(
         r'^\s*[ivxlc]{1,7}\s*$', re.I
     )
@@ -762,7 +765,7 @@ def _strip_running_headers(pages_text):
     for page_num, text in pages_text:
         lines = text.split('\n')
         cleaned = []
-        folio_candidates = []   # (rank, value)
+        page_printed_candidates = []   # (rank, value)
         for j, line in enumerate(lines):
             stripped = line.strip()
             if not stripped:
@@ -803,8 +806,8 @@ def _strip_running_headers(pages_text):
                         break
 
             # Capture-then-strip standalone page numbers (arabic or roman).
-            # This is the printed folio — the only address that is valid for
-            # citation. It used to be discarded here.
+            # This is the printed page number — the only address that is
+            # valid for citation. It used to be discarded here.
             #
             # The strip condition is unchanged. The capture condition is
             # narrower: an arabic run is taken at face value, but a roman
@@ -814,9 +817,9 @@ def _strip_running_headers(pages_text):
                 standalone_pagenum.match(stripped) or roman_pagenum.match(stripped)
             ):
                 if standalone_pagenum.match(stripped):
-                    folio_candidates.append((0 if is_near_bottom else 1, stripped))
-                elif _is_roman_folio(stripped.strip()):
-                    folio_candidates.append((0 if is_near_bottom else 1, stripped))
+                    page_printed_candidates.append((0 if is_near_bottom else 1, stripped))
+                elif _is_roman_page_number(stripped.strip()):
+                    page_printed_candidates.append((0 if is_near_bottom else 1, stripped))
                 continue
 
             # Strip "CHAPTER TITLE | page" or "page | BOOK TITLE" running headers
@@ -829,24 +832,25 @@ def _strip_running_headers(pages_text):
 
             # Strip a trailing page number appended to the last line. This
             # is a stripping rule ONLY — see the docstring. The number is
-            # NOT a folio candidate: the last line of a page legitimately
-            # ends in a number often enough ("...published in 1999") that
-            # capturing here publishes numbers that were never printed,
-            # poisons the offset derivation, and inflates folio_pages.
+            # NOT a page_printed candidate: the last line of a page
+            # legitimately ends in a number often enough ("...published in
+            # 1999") that capturing here publishes numbers that were never
+            # printed, poisons the offset derivation, and inflates
+            # page_printed_count.
             if is_last:
                 m_trail = re.search(r'\s+(\d{1,4})\s*$', line)
                 if m_trail:
                     line = line[:m_trail.start()]
 
             cleaned.append(line)
-        result.append((page_num, '\n'.join(cleaned), folio_candidates))
+        result.append((page_num, '\n'.join(cleaned), page_printed_candidates))
 
-    # Roman folios need corroboration. Real front matter runs several
+    # Roman page numbers need corroboration. Real front matter runs several
     # numbered pages, so >= 2 distinct roman captures across the document
     # is cheap evidence that we are looking at a numbering sequence. A lone
     # "I" or "Li" is far more likely to be English prose that survived as
-    # its own line, and emitting it would flip locator_type to "printed" on
-    # a book that has no printed folios at all.
+    # its own line, and emitting it would flip page_numbering to "printed"
+    # on a book that has no printed page numbers at all.
     roman_values = {
         value for _, _, cands in result
         for _, value in cands
@@ -854,7 +858,7 @@ def _strip_running_headers(pages_text):
     }
     romans_confirmed = len(roman_values) >= 2
     if roman_values and not romans_confirmed:
-        log.debug("Discarding %d unconfirmed roman folio capture(s): %r",
+        log.debug("Discarding %d unconfirmed roman page-number capture(s): %r",
                   len(roman_values), sorted(roman_values))
 
     finalized = []
@@ -864,23 +868,23 @@ def _strip_running_headers(pages_text):
         # Key on rank only: min() is stable, so equal ranks resolve to the
         # first candidate encountered. Comparing whole tuples would break
         # ties lexicographically by value ("12" < "47"), which is wrong.
-        folio = min(cands, key=lambda c: c[0])[1] if cands else None
-        finalized.append((page_num, cleaned_text, folio))
+        page_printed = min(cands, key=lambda c: c[0])[1] if cands else None
+        finalized.append((page_num, cleaned_text, page_printed))
 
     return finalized
 
 
 # Real roman-numeral grammar, not a bag of roman letters. The lookahead
 # rejects the empty match that every group-optional alternative allows.
-# This is what separates "xii" (a folio) from "ill" and "civil" (English
-# words that the loose stripping regex also matches).
-_ROMAN_FOLIO_RE = re.compile(
+# This is what separates "xii" (a printed page number) from "ill" and
+# "civil" (English words that the loose stripping regex also matches).
+_ROMAN_PAGE_NUMBER_RE = re.compile(
     r'^(?=[ivxlcdm])m{0,4}(?:cm|cd|d?c{0,3})(?:xc|xl|l?x{0,3})(?:ix|iv|v?i{0,3})$',
     re.I,
 )
 
 
-def _is_roman_folio(folio):
+def _is_roman_page_number(page_printed):
     """True only for a well-formed roman numeral like "xii".
 
     The stripping regex is a letter-bag (`[ivxlc]{1,7}`) that also matches
@@ -893,57 +897,59 @@ def _is_roman_folio(folio):
     requiring at least two distinct roman captures in the document before
     any of them counts.
     """
-    return bool(folio) and bool(_ROMAN_FOLIO_RE.match(folio))
+    return bool(page_printed) and bool(_ROMAN_PAGE_NUMBER_RE.match(page_printed))
 
 
-def _is_arabic_folio(folio):
-    """True only for a plain ASCII decimal folio like "47".
+def _is_arabic_page_number(page_printed):
+    """True only for a plain ASCII decimal page number like "47".
 
     `str.isdigit()` is too permissive: it accepts superscripts ("²", a
-    footnote marker that can reach folio_candidates) where `int()` then
-    raises ValueError and aborts the whole conversion, and it accepts
+    footnote marker that can reach page_printed_candidates) where `int()`
+    then raises ValueError and aborts the whole conversion, and it accepts
     Arabic-Indic digits, which are not a numbering sequence we can safely
     interpolate against. `.isascii() and .isdecimal()` admits exactly the
     characters `int()` will accept as a base-10 page number.
     """
-    return bool(folio) and folio.isascii() and folio.isdecimal()
+    return bool(page_printed) and page_printed.isascii() and page_printed.isdecimal()
 
 
-def _arabic_folio_sheets(folio_by_sheet):
-    """Sheets carrying an arabic captured folio — the interpolation window.
+def _arabic_page_pdf_indices(page_printed_by_pdf_index):
+    """PDF page indices carrying an arabic captured page number — the
+    interpolation window.
 
     Interpolation is permitted only BETWEEN captured samples, so the caller
-    clamps to the closed interval [min, max] of these sheets. Roman samples
-    are excluded here for the same reason they are excluded from offset
-    derivation: they belong to a separate numbering sequence and must not
-    widen the arabic window.
+    clamps to the closed interval [min, max] of these PDF page indices.
+    Roman samples are excluded here for the same reason they are excluded
+    from offset derivation: they belong to a separate numbering sequence
+    and must not widen the arabic window.
     """
     return [
-        sheet for sheet, folio in folio_by_sheet.items()
-        if _is_arabic_folio(folio)
+        page_pdf for page_pdf, page_printed in page_printed_by_pdf_index.items()
+        if _is_arabic_page_number(page_printed)
     ]
 
 
-def _derive_folio_offset(folio_by_sheet):
-    """Derive a constant sheet->folio offset from captured samples.
+def _derive_page_offset(page_printed_by_pdf_index):
+    """Derive a constant page_pdf->page_printed offset from captured samples.
 
-    Returns (offset, is_consistent). `offset` is folio - sheet. Consistency
-    requires at least 3 arabic samples that all agree; a book that renumbers
-    partway through (part-openers restarting at 1, roman-to-arabic front
-    matter) will disagree, and we refuse to interpolate rather than invent
-    page numbers. Roman folios never participate — they belong to a
-    separate numbering sequence.
+    Returns (offset, is_consistent). `offset` is page_printed - page_pdf.
+    Consistency requires at least 3 arabic samples that all agree; a book
+    that renumbers partway through (part-openers restarting at 1,
+    roman-to-arabic front matter) will disagree, and we refuse to
+    interpolate rather than invent page numbers. Roman page numbers never
+    participate — they belong to a separate numbering sequence.
 
     Args:
-        folio_by_sheet: dict of sheet index -> folio string
+        page_printed_by_pdf_index: dict of PDF page index -> printed page
+            number string
 
     Returns:
         (int | None, bool)
     """
     offsets = [
-        int(folio) - sheet
-        for sheet, folio in folio_by_sheet.items()
-        if _is_arabic_folio(folio)
+        int(page_printed) - page_pdf
+        for page_pdf, page_printed in page_printed_by_pdf_index.items()
+        if _is_arabic_page_number(page_printed)
     ]
     if len(offsets) < 3:
         return (None, False)
@@ -953,27 +959,27 @@ def _derive_folio_offset(folio_by_sheet):
 
 
 # What kind of page address each backend can produce. `pymupdf` is absent
-# because it decides at runtime (printed when folios were captured,
-# sheet-only otherwise) — see convert_with_pymupdf.
-BACKEND_LOCATOR_TYPE = {
-    "ocr": "sheet-only",
-    "pymupdf4llm": "sheet-only",
+# because it decides at runtime (printed when printed page numbers were
+# captured, pdf_only otherwise) — see convert_with_pymupdf.
+BACKEND_PAGE_NUMBERING = {
+    "ocr": "pdf_only",
+    "pymupdf4llm": "pdf_only",
     "marker": "none",
     "pandoc": "none",
     "docling": "none",
 }
 
 
-def _apply_backend_locator_type(report):
+def _apply_backend_page_numbering(report):
     """Stamp a backend's fixed locator capability onto its report.
 
     Backends that cannot produce a printed page number must declare it, so
     the ingestion gate can route away from them instead of silently filing
     a source that can never be cited by page.
     """
-    fixed = BACKEND_LOCATOR_TYPE.get(report.method)
+    fixed = BACKEND_PAGE_NUMBERING.get(report.method)
     if fixed:
-        report.locator_type = fixed
+        report.page_numbering = fixed
     return report
 
 
@@ -2462,33 +2468,37 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
     doc.close()
 
     # Strip running headers/footers across all pages, capturing the printed
-    # folio (the only citation-valid address) as we go.
+    # page number (the only citation-valid address) as we go.
     cleaned_pages = _strip_running_headers(raw_pages)
-    folio_by_sheet = {sheet: folio for sheet, _, folio in cleaned_pages if folio}
-    folio_offset, folio_consistent = _derive_folio_offset(folio_by_sheet)
+    page_printed_by_pdf_index = {
+        page_pdf: page_printed
+        for page_pdf, _, page_printed in cleaned_pages if page_printed
+    }
+    page_printed_offset, page_printed_offset_consistent = _derive_page_offset(page_printed_by_pdf_index)
     # Interpolation is permitted only BETWEEN captured samples. Outside that
     # span there is no evidence the offset still holds — endnotes or a second
     # numbering sequence past the last sample contribute no samples, so they
     # cannot disagree, and extrapolating there invents confident wrong page
     # numbers a reader cannot detect.
-    _arabic_sheets = _arabic_folio_sheets(folio_by_sheet)
-    folio_span = (
-        (min(_arabic_sheets), max(_arabic_sheets)) if _arabic_sheets else None
+    arabic_page_pdf_indices = _arabic_page_pdf_indices(page_printed_by_pdf_index)
+    page_pdf_span = (
+        (min(arabic_page_pdf_indices), max(arabic_page_pdf_indices)) if arabic_page_pdf_indices else None
     )
 
     skipped_toc_pages = 0
-    # folio_coverage's two terms MUST be counted over the same population:
-    # pages that actually emitted a locator. Blank-after-clean pages and
-    # replaced broken-TOC pages are `continue`d below and never get one.
+    # page_printed_coverage's two terms MUST be counted over the same
+    # population: pages that actually emitted a locator. Blank-after-clean
+    # pages and replaced broken-TOC pages are `continue`d below and never
+    # get one.
     #
     # Counting the denominator over `cleaned_pages` understates coverage.
-    # Counting the numerator over `folio_by_sheet` (which includes skipped
-    # pages) while the denominator excludes them is worse: the ratio can
-    # exceed 1.0, and a nonsensical >1.0 value sails straight through the
-    # ingestion gate's `>= threshold` check. Both are counted here, in the
-    # emit loop, so they cannot drift apart again.
+    # Counting the numerator over `page_printed_by_pdf_index` (which
+    # includes skipped pages) while the denominator excludes them is
+    # worse: the ratio can exceed 1.0, and a nonsensical >1.0 value sails
+    # straight through the ingestion gate's `>= threshold` check. Both are
+    # counted here, in the emit loop, so they cannot drift apart again.
     emitted_locator_pages = 0
-    emitted_folio_pages = 0
+    emitted_page_printed_pages = 0
 
     # errors="replace" is a safety net for any surrogate chars that slip
     # through the explicit _strip_surrogates() calls above
@@ -2515,7 +2525,7 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
         # content the user needs for keyword lookup.
         toc_skip_cutoff = max(20, total_pages // 10)
 
-        for page_num, text, folio in cleaned_pages:
+        for page_num, text, page_printed in cleaned_pages:
             # Detect index/glossary-style list pages so we can preserve
             # newlines instead of collapsing every entry into one paragraph.
             # Skip this in the front matter so _format_toc + broken-TOC
@@ -2543,36 +2553,37 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
                 skipped_toc_pages += 1
                 log.debug("Skipping broken TOC page %d", page_num)
                 continue
-            effective_folio = folio
-            if (effective_folio is None
-                    and folio_consistent
-                    and folio_span is not None
-                    and folio_span[0] <= page_num <= folio_span[1]):
-                candidate = page_num + folio_offset
-                # Never invent a folio for pages that precede printed page 1.
+            effective_page_printed = page_printed
+            if (effective_page_printed is None
+                    and page_printed_offset_consistent
+                    and page_pdf_span is not None
+                    and page_pdf_span[0] <= page_num <= page_pdf_span[1]):
+                candidate = page_num + page_printed_offset
+                # Never invent a printed page number for pages that precede
+                # printed page 1.
                 if candidate >= 1:
-                    effective_folio = str(candidate)
-            f.write(f"<!-- Page sheet={page_num} folio={effective_folio or 'none'} -->\n\n")
+                    effective_page_printed = str(candidate)
+            f.write(f"<!-- page_pdf={page_num} page_printed={effective_page_printed or 'none'} -->\n\n")
             emitted_locator_pages += 1
-            # `folio`, not `effective_folio`: folio_pages counts CAPTURED
-            # printed numbers, never interpolated ones.
-            if folio:
-                emitted_folio_pages += 1
+            # `page_printed`, not `effective_page_printed`: page_printed_count
+            # counts CAPTURED printed numbers, never interpolated ones.
+            if page_printed:
+                emitted_page_printed_pages += 1
             f.write(cleaned)
             f.write("\n\n")
 
     if skipped_toc_pages:
         print(f"  Replaced {skipped_toc_pages} broken TOC page(s) with embedded bookmark TOC")
 
-    report.total_locator_pages = emitted_locator_pages
-    report.folio_pages = emitted_folio_pages
-    report.folio_coverage = (
-        report.folio_pages / report.total_locator_pages
-        if report.total_locator_pages else 0.0
+    report.page_locator_count = emitted_locator_pages
+    report.page_printed_count = emitted_page_printed_pages
+    report.page_printed_coverage = (
+        report.page_printed_count / report.page_locator_count
+        if report.page_locator_count else 0.0
     )
-    report.locator_type = "printed" if report.folio_pages else "sheet-only"
-    report.folio_offset = folio_offset
-    report.folio_offset_consistent = folio_consistent
+    report.page_numbering = "printed" if report.page_printed_count else "pdf_only"
+    report.page_printed_offset = page_printed_offset
+    report.page_printed_offset_consistent = page_printed_offset_consistent
 
     # Check if we got enough text to consider this a real conversion
     if total_pages > 0 and (pages_with_text / total_pages) < MIN_TEXT_RATIO:
@@ -2743,7 +2754,7 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None):
             f"  tables: {report.tables_emitted} emitted / "
             f"{report.table_captions_seen} captions seen"
         )
-        _apply_backend_locator_type(report)
+        _apply_backend_page_numbering(report)
         report_path = target.with_suffix(".report.json")
         write_report(report_path, report)
         return report
@@ -2791,7 +2802,7 @@ def convert_with_ocr(pdf_path, output_dir):
                 text = pytesseract.image_to_string(images[0])
                 if text.strip():
                     pages_with_text += 1
-                    f.write(f"<!-- Page sheet={i} folio=none -->\n\n")
+                    f.write(f"<!-- page_pdf={i} page_printed=none -->\n\n")
                     cleaned = clean_text(text.strip())
                     cleaned = _format_headings(cleaned)
                     cleaned = _format_toc(cleaned)
@@ -2811,7 +2822,7 @@ def convert_with_ocr(pdf_path, output_dir):
     # it makes the OCR backend's table blindness visible in the sidecar
     # instead of leaving it to be discovered during a scholarly pass.
     apply_table_signals(report, output_file)
-    _apply_backend_locator_type(report)
+    _apply_backend_page_numbering(report)
     report_path = output_file.with_suffix(".report.json")
     write_report(report_path, report)
     return report
@@ -2869,7 +2880,7 @@ def convert_with_pandoc(book_path, output_dir):
     Images are referenced but not extracted (BookConvert is a text-only
     pipeline; pulling images would inflate output and break offline use).
     Returns a ConversionReport and writes the sidecar, like every other
-    backend; its `locator_type` is always "none" because an epub is
+    backend; its `page_numbering` is always "none" because an epub is
     reflowable and has no pages to address.
     Raises ConversionError on failure.
     """
@@ -2930,7 +2941,7 @@ def convert_with_pandoc(book_path, output_dir):
 
     # EPUB is reflowable: it has no pages, so no locator of any kind is
     # recoverable. That is exactly the case the ingestion gate most needs to
-    # detect, so pandoc writes a sidecar declaring `locator_type: "none"`
+    # detect, so pandoc writes a sidecar declaring `page_numbering: "none"`
     # rather than writing nothing — silence is indistinguishable from a
     # conversion that never ran. Page counts stay at their defaults; a
     # fabricated `total_pages` would be its own small lie.
@@ -2939,7 +2950,7 @@ def convert_with_pandoc(book_path, output_dir):
         output=str(output_file),
         method="pandoc",
     )
-    _apply_backend_locator_type(report)
+    _apply_backend_page_numbering(report)
     write_report(output_file.with_suffix(".report.json"), report)
     return report
 
@@ -2968,8 +2979,8 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
     # pymupdf4llm returns the full markdown as a string by default, OR
     # a list of per-page dicts when page_chunks=True. We use page_chunks
     # so we can emit page markers between chunks. Markers use the shared
-    # sheet/folio locator format; pymupdf4llm returns pre-cleaned text, so
-    # no printed folio is recoverable here.
+    # page_pdf/page_printed locator format; pymupdf4llm returns pre-cleaned
+    # text, so no printed page number is recoverable here.
     # pymupdf4llm sanitizes spaces in image_path to underscores when it
     # writes the PNGs, so we must sanitize the directory name ourselves
     # before mkdir — otherwise we'd create "Stem With Spaces_images/" and
@@ -2986,7 +2997,7 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
         page_chunks=True,
     )
 
-    # Stitch chunks with `<!-- Page sheet={N} folio=none -->` markers between
+    # Stitch chunks with `<!-- page_pdf={N} page_printed=none -->` markers between
     # them. pymupdf4llm's metadata.page_number is already 1-indexed (matches the
     # pymupdf backend's convention at line ~2280 above). Use it directly;
     # fall back to a 1-based enumeration if the key is missing for some
@@ -2995,7 +3006,7 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
     for idx, chunk in enumerate(page_chunks, start=1):
         page_num = chunk.get("metadata", {}).get("page_number", idx)
         chunk_text = chunk.get("text", "")
-        body_parts.append(f"<!-- Page sheet={page_num} folio=none -->\n\n{chunk_text}")
+        body_parts.append(f"<!-- page_pdf={page_num} page_printed=none -->\n\n{chunk_text}")
     markdown = "\n\n".join(body_parts)
 
     # pymupdf4llm embeds the full `image_path` we passed as the literal ref
@@ -3033,7 +3044,7 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
         pages_with_text=total_pages,  # pymupdf4llm handles its own detection
         extracted_assets=extracted_assets,
     )
-    _apply_backend_locator_type(report)
+    _apply_backend_page_numbering(report)
     write_report(output_file.with_suffix(".report.json"), report)
     return report
 
@@ -3077,7 +3088,7 @@ def convert_with_docling(pdf_path, output_dir):
         total_pages=total_pages,
         pages_with_text=total_pages,
     )
-    _apply_backend_locator_type(report)
+    _apply_backend_page_numbering(report)
     write_report(output_file.with_suffix(".report.json"), report)
     return report
 

--- a/convert.py
+++ b/convert.py
@@ -2477,11 +2477,18 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
     )
 
     skipped_toc_pages = 0
-    # Counts pages that actually emitted a locator comment. `cleaned_pages`
-    # is the wrong denominator: blank pages and replaced TOC pages are
-    # `continue`d below and never get a locator, so dividing by it reports
-    # a folio_coverage lower than the real one.
+    # folio_coverage's two terms MUST be counted over the same population:
+    # pages that actually emitted a locator. Blank-after-clean pages and
+    # replaced broken-TOC pages are `continue`d below and never get one.
+    #
+    # Counting the denominator over `cleaned_pages` understates coverage.
+    # Counting the numerator over `folio_by_sheet` (which includes skipped
+    # pages) while the denominator excludes them is worse: the ratio can
+    # exceed 1.0, and a nonsensical >1.0 value sails straight through the
+    # ingestion gate's `>= threshold` check. Both are counted here, in the
+    # emit loop, so they cannot drift apart again.
     emitted_locator_pages = 0
+    emitted_folio_pages = 0
 
     # errors="replace" is a safety net for any surrogate chars that slip
     # through the explicit _strip_surrogates() calls above
@@ -2547,6 +2554,10 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
                     effective_folio = str(candidate)
             f.write(f"<!-- Page sheet={page_num} folio={effective_folio or 'none'} -->\n\n")
             emitted_locator_pages += 1
+            # `folio`, not `effective_folio`: folio_pages counts CAPTURED
+            # printed numbers, never interpolated ones.
+            if folio:
+                emitted_folio_pages += 1
             f.write(cleaned)
             f.write("\n\n")
 
@@ -2554,7 +2565,7 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
         print(f"  Replaced {skipped_toc_pages} broken TOC page(s) with embedded bookmark TOC")
 
     report.total_locator_pages = emitted_locator_pages
-    report.folio_pages = len(folio_by_sheet)
+    report.folio_pages = emitted_folio_pages
     report.folio_coverage = (
         report.folio_pages / report.total_locator_pages
         if report.total_locator_pages else 0.0

--- a/convert.py
+++ b/convert.py
@@ -2772,6 +2772,9 @@ def convert_with_pandoc(book_path, output_dir):
     output keeps the book's natural reading order without page markers.
     Images are referenced but not extracted (BookConvert is a text-only
     pipeline; pulling images would inflate output and break offline use).
+    Returns a ConversionReport and writes the sidecar, like every other
+    backend; its `locator_type` is always "none" because an epub is
+    reflowable and has no pages to address.
     Raises ConversionError on failure.
     """
     print(f"Converting with pandoc: {book_path.name}")
@@ -2828,7 +2831,21 @@ def convert_with_pandoc(book_path, output_dir):
             f.write("\n")
 
     print(f"  -> {output_file}")
-    return True
+
+    # EPUB is reflowable: it has no pages, so no locator of any kind is
+    # recoverable. That is exactly the case the ingestion gate most needs to
+    # detect, so pandoc writes a sidecar declaring `locator_type: "none"`
+    # rather than writing nothing — silence is indistinguishable from a
+    # conversion that never ran. Page counts stay at their defaults; a
+    # fabricated `total_pages` would be its own small lie.
+    report = ConversionReport(
+        source=str(book_path),
+        output=str(output_file),
+        method="pandoc",
+    )
+    _apply_backend_locator_type(report)
+    write_report(output_file.with_suffix(".report.json"), report)
+    return report
 
 
 def convert_with_pymupdf4llm(pdf_path, output_dir):
@@ -3030,6 +3047,15 @@ def convert_book(book_path, output_dir, method="pymupdf", auto_ocr=False,
 
     try:
         if suffix == ".epub":
+            # Pandoc now returns a ConversionReport like its siblings and
+            # writes its own sidecar. The cleanup pass is deliberately NOT
+            # run here: it repairs PDF *extraction* artifacts (dropped-space
+            # joins, stray-consonant citation ghosts, pymupdf4llm
+            # picture-text garble) — see cleanup.py's module docstring, "PDF
+            # text extraction (all backends)". Pandoc's text comes from the
+            # epub's HTML, which carries none of those defects, so running
+            # the pass would be spending a dictionary sweep on text that
+            # cannot need it.
             return bool(convert_with_pandoc(book_path, output_dir))
         if method == "ocr":
             result = convert_with_ocr(book_path, output_dir)

--- a/convert.py
+++ b/convert.py
@@ -817,6 +817,34 @@ def _strip_running_headers(pages_text):
     return result
 
 
+def _is_arabic_folio(folio):
+    """True only for a plain ASCII decimal folio like "47".
+
+    `str.isdigit()` is too permissive: it accepts superscripts ("²", a
+    footnote marker that can reach folio_candidates) where `int()` then
+    raises ValueError and aborts the whole conversion, and it accepts
+    Arabic-Indic digits, which are not a numbering sequence we can safely
+    interpolate against. `.isascii() and .isdecimal()` admits exactly the
+    characters `int()` will accept as a base-10 page number.
+    """
+    return bool(folio) and folio.isascii() and folio.isdecimal()
+
+
+def _arabic_folio_sheets(folio_by_sheet):
+    """Sheets carrying an arabic captured folio — the interpolation window.
+
+    Interpolation is permitted only BETWEEN captured samples, so the caller
+    clamps to the closed interval [min, max] of these sheets. Roman samples
+    are excluded here for the same reason they are excluded from offset
+    derivation: they belong to a separate numbering sequence and must not
+    widen the arabic window.
+    """
+    return [
+        sheet for sheet, folio in folio_by_sheet.items()
+        if _is_arabic_folio(folio)
+    ]
+
+
 def _derive_folio_offset(folio_by_sheet):
     """Derive a constant sheet->folio offset from captured samples.
 
@@ -836,13 +864,12 @@ def _derive_folio_offset(folio_by_sheet):
     offsets = [
         int(folio) - sheet
         for sheet, folio in folio_by_sheet.items()
-        if folio.isdigit()
+        if _is_arabic_folio(folio)
     ]
     if len(offsets) < 3:
         return (None, False)
-    first = offsets[0]
-    if all(o == first for o in offsets):
-        return (first, True)
+    if len(set(offsets)) == 1:
+        return (offsets[0], True)
     return (None, False)
 
 
@@ -2335,6 +2362,15 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
     cleaned_pages = _strip_running_headers(raw_pages)
     folio_by_sheet = {sheet: folio for sheet, _, folio in cleaned_pages if folio}
     folio_offset, folio_consistent = _derive_folio_offset(folio_by_sheet)
+    # Interpolation is permitted only BETWEEN captured samples. Outside that
+    # span there is no evidence the offset still holds — endnotes or a second
+    # numbering sequence past the last sample contribute no samples, so they
+    # cannot disagree, and extrapolating there invents confident wrong page
+    # numbers a reader cannot detect.
+    _arabic_sheets = _arabic_folio_sheets(folio_by_sheet)
+    folio_span = (
+        (min(_arabic_sheets), max(_arabic_sheets)) if _arabic_sheets else None
+    )
 
     skipped_toc_pages = 0
 
@@ -2392,7 +2428,10 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
                 log.debug("Skipping broken TOC page %d", page_num)
                 continue
             effective_folio = folio
-            if effective_folio is None and folio_consistent:
+            if (effective_folio is None
+                    and folio_consistent
+                    and folio_span is not None
+                    and folio_span[0] <= page_num <= folio_span[1]):
                 candidate = page_num + folio_offset
                 # Never invent a folio for pages that precede printed page 1.
                 if candidate >= 1:

--- a/report.py
+++ b/report.py
@@ -37,17 +37,18 @@ class ConversionReport:
     # failure mode a spot-check of three pages will not catch.
     tables_emitted: int = 0
     table_captions_seen: int = 0
-    # Page-locator signals. `locator_type` declares what kind of address
+    # Page-locator signals. `page_numbering` declares what kind of address
     # this conversion can produce: "printed" (a real page number appears
-    # on the page), "sheet-only" (PDF sheet index only), or "none" (the
-    # backend emits no locators at all). `folio_offset` is folio - sheet,
-    # meaningful only when `folio_offset_consistent` is True.
-    locator_type: str = "none"
-    folio_pages: int = 0
-    total_locator_pages: int = 0
-    folio_coverage: float = 0.0
-    folio_offset: int | None = None
-    folio_offset_consistent: bool = False
+    # on the page), "pdf_only" (PDF page index only), or "none" (the
+    # backend emits no locators at all). `page_printed_offset` is
+    # page_printed - page_pdf, meaningful only when
+    # `page_printed_offset_consistent` is True.
+    page_numbering: str = "none"
+    page_printed_count: int = 0
+    page_locator_count: int = 0
+    page_printed_coverage: float = 0.0
+    page_printed_offset: int | None = None
+    page_printed_offset_consistent: bool = False
     warnings: List[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:

--- a/report.py
+++ b/report.py
@@ -37,6 +37,17 @@ class ConversionReport:
     # failure mode a spot-check of three pages will not catch.
     tables_emitted: int = 0
     table_captions_seen: int = 0
+    # Page-locator signals. `locator_type` declares what kind of address
+    # this conversion can produce: "printed" (a real page number appears
+    # on the page), "sheet-only" (PDF sheet index only), or "none" (the
+    # backend emits no locators at all). `folio_offset` is folio - sheet,
+    # meaningful only when `folio_offset_consistent` is True.
+    locator_type: str = "none"
+    folio_pages: int = 0
+    total_locator_pages: int = 0
+    folio_coverage: float = 0.0
+    folio_offset: int | None = None
+    folio_offset_consistent: bool = False
     warnings: List[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -47,43 +47,45 @@ def build_figure_pdf(tmp_path: Path) -> Path:
     return out
 
 
-def build_foliated_pdf(
+def build_page_printed_pdf(
     tmp_path: Path,
     pages: int = 8,
     offset: int = -4,
-    skip_folios_on: tuple = (),
+    skip_page_printed_on: tuple = (),
     body_only_footer_on: tuple = (),
-    name: str = "foliated.pdf",
+    name: str = "page_printed.pdf",
 ) -> Path:
-    """Build a PDF whose pages carry a printed folio in the footer.
+    """Build a PDF whose pages carry a printed page number in the footer.
 
-    Sheet i (1-based) prints folio i + offset. With the default offset of
-    -4, sheet 5 prints "1" — i.e. four pages of unnumbered front matter,
-    the common real-world shape. Pages whose computed folio is < 1 print
-    no footer at all, standing in for a cover and title page.
+    PDF page i (1-based) prints page number i + offset. With the default
+    offset of -4, PDF page 5 prints "1" — i.e. four pages of unnumbered
+    front matter, the common real-world shape. Pages whose computed
+    printed number is < 1 print no footer at all, standing in for a cover
+    and title page.
 
-    `skip_folios_on` names sheets that print NO footer even though their
-    folio would be >= 1 — standing in for the real-world case where the
-    printed number was lost to extraction (OCR miss, figure-covered
-    footer). Those sheets are the ones interpolation must fill in.
+    `skip_page_printed_on` names PDF pages that print NO footer even
+    though their printed number would be >= 1 — standing in for the
+    real-world case where the printed number was lost to extraction (OCR
+    miss, figure-covered footer). Those pages are the ones interpolation
+    must fill in.
 
-    `body_only_footer_on` names sheets that carry their printed footer but
-    NO body text — the numbered-but-blank verso of a part divider. After
-    header stripping those pages clean to nothing and are dropped before a
-    locator is emitted, so they must not count toward the folio_coverage
-    denominator.
+    `body_only_footer_on` names PDF pages that carry their printed footer
+    but NO body text — the numbered-but-blank verso of a part divider.
+    After header stripping those pages clean to nothing and are dropped
+    before a locator is emitted, so they must not count toward the
+    page_printed_coverage denominator.
     """
     out = tmp_path / name
     doc = fitz.open()
-    skip = set(skip_folios_on)
+    skip = set(skip_page_printed_on)
     footer_only = set(body_only_footer_on)
     for i in range(1, pages + 1):
         page = doc.new_page(width=612, height=792)
         if i not in footer_only:
-            page.insert_text((72, 100), f"Body text for sheet {i}.")
-        folio = i + offset
-        if folio >= 1 and i not in skip:
-            page.insert_text((300, 740), str(folio))
+            page.insert_text((72, 100), f"Body text for page {i}.")
+        page_printed = i + offset
+        if page_printed >= 1 and i not in skip:
+            page.insert_text((300, 740), str(page_printed))
     doc.save(str(out))
     doc.close()
     return out
@@ -96,11 +98,11 @@ def build_trailing_number_pdf(
 ) -> Path:
     """Build a PDF whose body text legitimately ENDS in a number.
 
-    No page carries a printed folio. Every page's last line of prose ends
-    with a year, standing in for the very common real-world shape where a
-    page's closing sentence ends in a number and the real footer never
-    survived extraction. Nothing here was ever printed as a page number, so
-    every sheet must report `folio=none`.
+    No page carries a printed page number. Every page's last line of prose
+    ends with a year, standing in for the very common real-world shape
+    where a page's closing sentence ends in a number and the real footer
+    never survived extraction. Nothing here was ever printed as a page
+    number, so every page must report `page_printed=none`.
 
     The closing sentences deliberately DIFFER from page to page. An
     identical closing line would be detected as a repeating running footer
@@ -125,7 +127,7 @@ def build_trailing_number_pdf(
     doc = fitz.open()
     for i in range(1, pages + 1):
         page = doc.new_page(width=612, height=792)
-        page.insert_text((72, 100), f"Body text for sheet {i}.")
+        page.insert_text((72, 100), f"Body text for page {i}.")
         page.insert_text(
             (72, 130), f"{prose[(i - 1) % len(prose)]} {1990 + i}"
         )
@@ -141,7 +143,7 @@ def build_roman_wordlike_pdf(tmp_path: Path, name: str = "romanish.pdf") -> Path
     regex `[ivxlc]{1,7}`, but they are English words sitting on their own
     line (a dropped caption, a hyphenation artifact, a one-word line). No
     page here carries a printed number, so the book must come out
-    sheet-only.
+    pdf_only.
     """
     out = tmp_path / name
     doc = fitz.open()
@@ -149,7 +151,7 @@ def build_roman_wordlike_pdf(tmp_path: Path, name: str = "romanish.pdf") -> Path
     for i in range(1, 9):
         page = doc.new_page(width=612, height=792)
         page.insert_text((72, 100), words[(i - 1) % len(words)])
-        page.insert_text((72, 130), f"Body text for sheet {i}.")
+        page.insert_text((72, 130), f"Body text for page {i}.")
     doc.save(str(out))
     doc.close()
     return out
@@ -158,19 +160,19 @@ def build_roman_wordlike_pdf(tmp_path: Path, name: str = "romanish.pdf") -> Path
 def build_renumbering_pdf(tmp_path: Path, name: str = "renumber.pdf") -> Path:
     """Build a PDF whose printed numbering RESTARTS partway through.
 
-    Sheets 3-8 print folios 1-6 (offset -2). Sheet 9 onward is a second
-    section restarting at 1 (offset -8), the shape of endnotes or a
+    Pages 3-8 print page numbers 1-6 (offset -2). Page 9 onward is a
+    second section restarting at 1 (offset -8), the shape of endnotes or a
     part-opener that resets. No single constant offset explains both runs,
-    so `_derive_folio_offset` must refuse and NOTHING may be interpolated.
+    so `_derive_page_offset` must refuse and NOTHING may be interpolated.
 
-    Sheets 12 and 14 print no footer at all — those are the uncaptured
-    sheets a buggy implementation would fill with confident wrong numbers.
+    Pages 12 and 14 print no footer at all — those are the uncaptured
+    pages a buggy implementation would fill with confident wrong numbers.
     """
     out = tmp_path / name
     doc = fitz.open()
     for i in range(1, 17):
         page = doc.new_page(width=612, height=792)
-        page.insert_text((72, 100), f"Body text for sheet {i}.")
+        page.insert_text((72, 100), f"Body text for page {i}.")
         if i in (12, 14):
             continue  # printed number lost to extraction
         if 3 <= i <= 8:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -52,6 +52,7 @@ def build_foliated_pdf(
     pages: int = 8,
     offset: int = -4,
     skip_folios_on: tuple = (),
+    body_only_footer_on: tuple = (),
     name: str = "foliated.pdf",
 ) -> Path:
     """Build a PDF whose pages carry a printed folio in the footer.
@@ -65,16 +66,90 @@ def build_foliated_pdf(
     folio would be >= 1 — standing in for the real-world case where the
     printed number was lost to extraction (OCR miss, figure-covered
     footer). Those sheets are the ones interpolation must fill in.
+
+    `body_only_footer_on` names sheets that carry their printed footer but
+    NO body text — the numbered-but-blank verso of a part divider. After
+    header stripping those pages clean to nothing and are dropped before a
+    locator is emitted, so they must not count toward the folio_coverage
+    denominator.
     """
     out = tmp_path / name
     doc = fitz.open()
     skip = set(skip_folios_on)
+    footer_only = set(body_only_footer_on)
     for i in range(1, pages + 1):
         page = doc.new_page(width=612, height=792)
-        page.insert_text((72, 100), f"Body text for sheet {i}.")
+        if i not in footer_only:
+            page.insert_text((72, 100), f"Body text for sheet {i}.")
         folio = i + offset
         if folio >= 1 and i not in skip:
             page.insert_text((300, 740), str(folio))
+    doc.save(str(out))
+    doc.close()
+    return out
+
+
+def build_trailing_number_pdf(
+    tmp_path: Path,
+    pages: int = 8,
+    name: str = "trailing.pdf",
+) -> Path:
+    """Build a PDF whose body text legitimately ENDS in a number.
+
+    No page carries a printed folio. Every page's last line of prose ends
+    with a year, standing in for the very common real-world shape where a
+    page's closing sentence ends in a number and the real footer never
+    survived extraction. Nothing here was ever printed as a page number, so
+    every sheet must report `folio=none`.
+
+    The closing sentences deliberately DIFFER from page to page. An
+    identical closing line would be detected as a repeating running footer
+    and removed whole, so the trailing-number branch this fixture exists to
+    exercise would never be reached.
+    """
+    prose = [
+        "The study was published in",
+        "The print run sold roughly",
+        "The trial ran for",
+        "The firm employed some",
+        "The division grew to",
+        "The strike lasted about",
+        "The audience reached nearly",
+        "The revision shipped in",
+        "The survey covered exactly",
+        "The programme spanned some",
+        "The refit cost about",
+        "The agency hired around",
+    ]
+    out = tmp_path / name
+    doc = fitz.open()
+    for i in range(1, pages + 1):
+        page = doc.new_page(width=612, height=792)
+        page.insert_text((72, 100), f"Body text for sheet {i}.")
+        page.insert_text(
+            (72, 130), f"{prose[(i - 1) % len(prose)]} {1990 + i}"
+        )
+    doc.save(str(out))
+    doc.close()
+    return out
+
+
+def build_roman_wordlike_pdf(tmp_path: Path, name: str = "romanish.pdf") -> Path:
+    """Build a PDF with standalone lines that LOOK like roman numerals.
+
+    "I", "ill" and "civil" are all matched by the loose roman stripping
+    regex `[ivxlc]{1,7}`, but they are English words sitting on their own
+    line (a dropped caption, a hyphenation artifact, a one-word line). No
+    page here carries a printed number, so the book must come out
+    sheet-only.
+    """
+    out = tmp_path / name
+    doc = fitz.open()
+    words = ["I", "ill", "civil", "ill", "civil", "I", "ill", "civil"]
+    for i in range(1, 9):
+        page = doc.new_page(width=612, height=792)
+        page.insert_text((72, 100), words[(i - 1) % len(words)])
+        page.insert_text((72, 130), f"Body text for sheet {i}.")
     doc.save(str(out))
     doc.close()
     return out

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -46,22 +46,61 @@ def build_figure_pdf(tmp_path: Path) -> Path:
     return out
 
 
-def build_foliated_pdf(tmp_path: Path, pages: int = 8, offset: int = -4) -> Path:
+def build_foliated_pdf(
+    tmp_path: Path,
+    pages: int = 8,
+    offset: int = -4,
+    skip_folios_on: tuple = (),
+    name: str = "foliated.pdf",
+) -> Path:
     """Build a PDF whose pages carry a printed folio in the footer.
 
     Sheet i (1-based) prints folio i + offset. With the default offset of
     -4, sheet 5 prints "1" — i.e. four pages of unnumbered front matter,
     the common real-world shape. Pages whose computed folio is < 1 print
     no footer at all, standing in for a cover and title page.
+
+    `skip_folios_on` names sheets that print NO footer even though their
+    folio would be >= 1 — standing in for the real-world case where the
+    printed number was lost to extraction (OCR miss, figure-covered
+    footer). Those sheets are the ones interpolation must fill in.
     """
-    out = tmp_path / "foliated.pdf"
+    out = tmp_path / name
     doc = fitz.open()
+    skip = set(skip_folios_on)
     for i in range(1, pages + 1):
         page = doc.new_page(width=612, height=792)
         page.insert_text((72, 100), f"Body text for sheet {i}.")
         folio = i + offset
-        if folio >= 1:
+        if folio >= 1 and i not in skip:
             page.insert_text((300, 740), str(folio))
+    doc.save(str(out))
+    doc.close()
+    return out
+
+
+def build_renumbering_pdf(tmp_path: Path, name: str = "renumber.pdf") -> Path:
+    """Build a PDF whose printed numbering RESTARTS partway through.
+
+    Sheets 3-8 print folios 1-6 (offset -2). Sheet 9 onward is a second
+    section restarting at 1 (offset -8), the shape of endnotes or a
+    part-opener that resets. No single constant offset explains both runs,
+    so `_derive_folio_offset` must refuse and NOTHING may be interpolated.
+
+    Sheets 12 and 14 print no footer at all — those are the uncaptured
+    sheets a buggy implementation would fill with confident wrong numbers.
+    """
+    out = tmp_path / name
+    doc = fitz.open()
+    for i in range(1, 17):
+        page = doc.new_page(width=612, height=792)
+        page.insert_text((72, 100), f"Body text for sheet {i}.")
+        if i in (12, 14):
+            continue  # printed number lost to extraction
+        if 3 <= i <= 8:
+            page.insert_text((300, 740), str(i - 2))
+        elif i >= 9:
+            page.insert_text((300, 740), str(i - 8))
     doc.save(str(out))
     doc.close()
     return out

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,6 +4,7 @@ Every test that needs a PDF calls one of these builders instead of
 committing a binary fixture to the repo. Each builder returns a Path
 to a file inside the tmp_path fixture directory.
 """
+import zipfile
 from pathlib import Path
 
 import fitz
@@ -144,4 +145,81 @@ def build_scanned_pdf(tmp_path: Path) -> Path:
         page.insert_image(page.rect, stream=img_bytes)
     doc.save(str(out))
     doc.close()
+    return out
+
+
+def build_minimal_epub(tmp_path: Path, name: str = "minimal.epub") -> Path:
+    """Build the smallest valid EPUB 2 that pandoc will convert.
+
+    An EPUB is a zip with an uncompressed `mimetype` entry first, a
+    META-INF/container.xml pointing at the OPF package, and at least one
+    XHTML content document. Synthesized rather than committed so the repo
+    keeps no binary fixtures.
+    """
+    out = tmp_path / name
+
+    container = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<container version="1.0" '
+        'xmlns="urn:oasis:names:tc:opendocument:xmlns:container">\n'
+        '  <rootfiles>\n'
+        '    <rootfile full-path="OEBPS/content.opf" '
+        'media-type="application/oebps-package+xml"/>\n'
+        '  </rootfiles>\n'
+        '</container>\n'
+    )
+    opf = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<package xmlns="http://www.idpf.org/2007/opf" version="2.0" '
+        'unique-identifier="bookid">\n'
+        '  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">\n'
+        '    <dc:title>Minimal Book</dc:title>\n'
+        '    <dc:language>en</dc:language>\n'
+        '    <dc:identifier id="bookid">urn:uuid:bookconvert-test</dc:identifier>\n'
+        '  </metadata>\n'
+        '  <manifest>\n'
+        '    <item id="ch1" href="ch1.xhtml" media-type="application/xhtml+xml"/>\n'
+        '    <item id="ncx" href="toc.ncx" '
+        'media-type="application/x-dtbncx+xml"/>\n'
+        '  </manifest>\n'
+        '  <spine toc="ncx">\n'
+        '    <itemref idref="ch1"/>\n'
+        '  </spine>\n'
+        '</package>\n'
+    )
+    ncx = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">\n'
+        '  <head><meta name="dtb:uid" content="urn:uuid:bookconvert-test"/></head>\n'
+        '  <docTitle><text>Minimal Book</text></docTitle>\n'
+        '  <navMap>\n'
+        '    <navPoint id="np1" playOrder="1">\n'
+        '      <navLabel><text>Chapter One</text></navLabel>\n'
+        '      <content src="ch1.xhtml"/>\n'
+        '    </navPoint>\n'
+        '  </navMap>\n'
+        '</ncx>\n'
+    )
+    ch1 = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<html xmlns="http://www.w3.org/1999/xhtml">\n'
+        '  <head><title>Chapter One</title></head>\n'
+        '  <body>\n'
+        '    <h1>Chapter One</h1>\n'
+        '    <p>An epub is reflowable, so it has no printed page numbers.</p>\n'
+        '  </body>\n'
+        '</html>\n'
+    )
+
+    with zipfile.ZipFile(out, "w") as zf:
+        # The mimetype entry must be first and stored uncompressed.
+        zf.writestr(
+            zipfile.ZipInfo("mimetype"),
+            "application/epub+zip",
+            compress_type=zipfile.ZIP_STORED,
+        )
+        zf.writestr("META-INF/container.xml", container)
+        zf.writestr("OEBPS/content.opf", opf)
+        zf.writestr("OEBPS/toc.ncx", ncx)
+        zf.writestr("OEBPS/ch1.xhtml", ch1)
     return out

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -46,6 +46,27 @@ def build_figure_pdf(tmp_path: Path) -> Path:
     return out
 
 
+def build_foliated_pdf(tmp_path: Path, pages: int = 8, offset: int = -4) -> Path:
+    """Build a PDF whose pages carry a printed folio in the footer.
+
+    Sheet i (1-based) prints folio i + offset. With the default offset of
+    -4, sheet 5 prints "1" — i.e. four pages of unnumbered front matter,
+    the common real-world shape. Pages whose computed folio is < 1 print
+    no footer at all, standing in for a cover and title page.
+    """
+    out = tmp_path / "foliated.pdf"
+    doc = fitz.open()
+    for i in range(1, pages + 1):
+        page = doc.new_page(width=612, height=792)
+        page.insert_text((72, 100), f"Body text for sheet {i}.")
+        folio = i + offset
+        if folio >= 1:
+            page.insert_text((300, 740), str(folio))
+    doc.save(str(out))
+    doc.close()
+    return out
+
+
 def build_raster_image_pdf(tmp_path: Path) -> Path:
     """Build a PDF with one page containing a real embedded raster image.
 

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -171,3 +171,102 @@ def test_interpolates_folio_on_unnumbered_pages(tmp_path):
     assert "<!-- Page sheet=1 folio=none -->" in md
     assert "folio=0" not in md
     assert "folio=-" not in md
+
+
+def test_derive_offset_tolerates_non_ascii_digit_folio():
+    """A superscript footnote marker must not crash the conversion.
+
+    `"²".isdigit()` is True but `int("²")` raises ValueError. The arabic
+    test is `.isascii() and .isdecimal()`, so the marker is simply ignored.
+    """
+    import convert
+    samples = {5: "²", 10: "6", 20: "16", 30: "26"}
+    offset, consistent = convert._derive_folio_offset(samples)
+    assert offset == -4
+    assert consistent is True
+
+
+def test_derive_offset_ignores_arabic_indic_digits():
+    import convert
+    # U+0666 ARABIC-INDIC DIGIT SIX: isdigit() True, not ASCII decimal.
+    samples = {5: "٦", 10: "6", 20: "16", 30: "26"}
+    offset, consistent = convert._derive_folio_offset(samples)
+    assert offset == -4
+    assert consistent is True
+
+
+def test_interpolates_missing_mid_body_folios(tmp_path):
+    """Sheets whose printed folio was lost to extraction get filled in."""
+    import convert
+    from tests import fixtures
+
+    # Sheets 5-12 print folios 1-8; sheets 7 and 9 lost their footer.
+    pdf = fixtures.build_foliated_pdf(
+        tmp_path, pages=12, offset=-4, skip_folios_on=(7, 9)
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
+
+    assert report.folio_offset == -4
+    assert report.folio_offset_consistent is True
+    # The two gaps are interpolated to their true printed numbers.
+    assert "<!-- Page sheet=7 folio=3 -->" in md
+    assert "<!-- Page sheet=9 folio=5 -->" in md
+    # folio_pages counts CAPTURED folios only: sheets 5,6,8,10,11,12.
+    assert report.folio_pages == 6
+    # Front matter still refuses to invent a folio.
+    assert "<!-- Page sheet=1 folio=none -->" in md
+    assert "folio=0" not in md
+    assert "folio=-" not in md
+
+
+def test_no_extrapolation_past_the_last_captured_sample(tmp_path):
+    """Beyond the captured span there is no evidence the offset holds.
+
+    A real book's endnotes often restart at 1 and never survive extraction;
+    they contribute no samples, so they cannot disagree. Extrapolating there
+    would emit confident wrong numbers, so we clamp to [min, max] sample.
+    """
+    import convert
+    from tests import fixtures
+
+    # Sheets 5-12 print folios 1-8. Sheets 13-16 print nothing.
+    pdf = fixtures.build_foliated_pdf(
+        tmp_path, pages=16, offset=-4, skip_folios_on=(13, 14, 15, 16)
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
+
+    assert report.folio_offset == -4
+    assert report.folio_offset_consistent is True
+    for sheet in (13, 14, 15, 16):
+        assert f"<!-- Page sheet={sheet} folio=none -->" in md
+    # The would-be extrapolated numbers must appear nowhere.
+    for bad in ("folio=9", "folio=10", "folio=11", "folio=12"):
+        assert bad not in md
+
+
+def test_renumbering_book_gets_no_interpolation_in_markdown(tmp_path):
+    """The emission layer, not just the helper, must refuse an inconsistent book."""
+    import convert
+    from tests import fixtures
+
+    pdf = fixtures.build_renumbering_pdf(tmp_path)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
+
+    assert report.folio_offset_consistent is False
+    assert report.folio_offset is None
+    # Sheets 12 and 14 lost their printed number. With two disagreeing
+    # numbering runs we must emit `none`, never a guess.
+    assert "<!-- Page sheet=12 folio=none -->" in md
+    assert "<!-- Page sheet=14 folio=none -->" in md
+    # Sheets 1-2 carry no printed number at all and stay `none`.
+    assert "<!-- Page sheet=1 folio=none -->" in md
+    assert "<!-- Page sheet=2 folio=none -->" in md

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -469,9 +469,45 @@ def test_total_locator_pages_counts_only_emitted_locators(tmp_path):
     assert "<!-- Page sheet=6 " not in md
     assert "<!-- Page sheet=10 " not in md
     assert report.total_locator_pages == emitted
-    assert report.folio_coverage == pytest.approx(
-        report.folio_pages / emitted
+    # Both terms are counted over the SAME population. Sheets 5-12 all
+    # carried a printed footer, but 6 and 10 never emitted a locator, so
+    # the numerator is 6 -- not the 8 folios that were captured.
+    assert report.folio_pages == 6
+    assert report.folio_coverage == pytest.approx(6 / 10)
+    assert report.folio_coverage <= 1.0
+
+
+def test_folio_coverage_never_exceeds_one(tmp_path):
+    """The ratio is a coverage fraction; >1.0 is meaningless by construction.
+
+    Worth asserting outright because a >1.0 value is not merely wrong, it is
+    wrong in the unsafe direction: it sails through the ingestion gate's
+    `>= threshold` check while describing nothing real.
+
+    Every sheet that carries a printed folio here is also body-less, so it
+    is dropped before a locator is written. A numerator counted over
+    captured folios (8) against a denominator counted over emitted
+    locators (4) yields 2.0.
+    """
+    import convert
+    from tests import fixtures
+
+    pdf = fixtures.build_foliated_pdf(
+        tmp_path, pages=12, offset=-4,
+        body_only_footer_on=tuple(range(5, 13)),
     )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
+
+    assert report.total_locator_pages == md.count("<!-- Page sheet=") == 4
+    assert report.folio_pages == 0
+    assert report.folio_coverage == 0.0
+    assert 0.0 <= report.folio_coverage <= 1.0
+    # A book whose every captured folio was dropped has no citable printed
+    # address left, and must not claim otherwise.
+    assert report.locator_type == "sheet-only"
 
 
 LOCATOR_TYPES = {"printed", "sheet-only", "none"}

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -290,3 +290,63 @@ def test_backend_locator_declarations(method, expected):
     convert._apply_backend_locator_type(report)
     assert report.locator_type == expected
     assert report.locator_type in LOCATOR_TYPES
+
+
+def test_pandoc_epub_conversion_writes_a_none_locator_sidecar(tmp_path):
+    """An EPUB can never carry a printed page number — say so in the sidecar.
+
+    This is the case the ingestion gate most needs to detect. A pandoc run
+    that wrote no sidecar at all would be indistinguishable from a
+    conversion that never ran, which is the original bug this bet exists to
+    kill.
+    """
+    import shutil
+
+    import convert
+    from tests import fixtures
+
+    if shutil.which("pandoc") is None:
+        pytest.skip("pandoc not installed")
+
+    epub = fixtures.build_minimal_epub(tmp_path)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    report = convert.convert_with_pandoc(epub, out_dir)
+
+    # Pandoc now returns a ConversionReport like every other backend.
+    assert isinstance(report, ConversionReport)
+    assert report.method == "pandoc"
+    assert report.locator_type == "none"
+
+    sidecar = out_dir / f"{epub.stem}.report.json"
+    assert sidecar.exists()
+    data = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert data["method"] == "pandoc"
+    assert data["locator_type"] == "none"
+    # Page counts stay at their defaults; an epub has no pages to count.
+    assert not data.get("total_pages")
+
+
+def test_convert_book_epub_route_produces_a_sidecar(tmp_path):
+    """The dispatch path, not just the backend, must leave a sidecar behind."""
+    import shutil
+
+    import convert
+    from tests import fixtures
+
+    if shutil.which("pandoc") is None:
+        pytest.skip("pandoc not installed")
+
+    epub = fixtures.build_minimal_epub(tmp_path, name="dispatch.epub")
+    out_dir = tmp_path / "out"
+
+    assert convert.convert_book(epub, out_dir) is True
+
+    sidecar = out_dir / "dispatch.report.json"
+    assert sidecar.exists()
+    data = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert data["locator_type"] == "none"
+    # Cleanup is deliberately skipped on the epub route (it repairs PDF
+    # extraction artifacts), so the sidecar must not claim it ran.
+    assert not data.get("cleaned")

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -1,4 +1,4 @@
-"""Tests for typed page locators: sheet index + printed folio capture."""
+"""Tests for typed page locators: PDF page index + printed page number capture."""
 import json
 from pathlib import Path
 
@@ -9,27 +9,28 @@ from report import ConversionReport, write_report
 
 def test_report_defaults_to_no_locator():
     r = ConversionReport(source="in.pdf", output="out.md", method="pymupdf")
-    assert r.locator_type == "none"
-    assert r.folio_pages == 0
-    assert r.total_locator_pages == 0
-    assert r.folio_coverage == 0.0
-    assert r.folio_offset is None
-    assert r.folio_offset_consistent is False
+    assert r.page_numbering == "none"
+    assert r.page_printed_count == 0
+    assert r.page_locator_count == 0
+    assert r.page_printed_coverage == 0.0
+    assert r.page_printed_offset is None
+    assert r.page_printed_offset_consistent is False
 
 
 def test_report_locator_fields_round_trip(tmp_path):
     r = ConversionReport(
         source="in.pdf", output="out.md", method="pymupdf",
-        locator_type="printed", folio_pages=20, total_locator_pages=319,
-        folio_coverage=0.0627, folio_offset=-12, folio_offset_consistent=True,
+        page_numbering="printed", page_printed_count=20, page_locator_count=319,
+        page_printed_coverage=0.0627, page_printed_offset=-12,
+        page_printed_offset_consistent=True,
     )
     p = tmp_path / "out.report.json"
     write_report(p, r)
     data = json.loads(p.read_text(encoding="utf-8"))
-    assert data["locator_type"] == "printed"
-    assert data["folio_pages"] == 20
-    assert data["folio_offset"] == -12
-    assert data["folio_offset_consistent"] is True
+    assert data["page_numbering"] == "printed"
+    assert data["page_printed_count"] == 20
+    assert data["page_printed_offset"] == -12
+    assert data["page_printed_offset_consistent"] is True
 
 
 def test_strip_running_headers_returns_three_tuples():
@@ -39,18 +40,18 @@ def test_strip_running_headers_returns_three_tuples():
     assert all(len(t) == 3 for t in result)
 
 
-def test_captures_bottom_standalone_folio():
+def test_captures_bottom_standalone_page_printed():
     import convert
-    # Sheet i carries printed folio i+10 as a standalone bottom line.
+    # PDF page i carries printed page number i+10 as a standalone bottom line.
     pages = [(i, f"Body text for page {i}.\n{i + 10}") for i in range(1, 8)]
     result = convert._strip_running_headers(pages)
-    folios = [folio for _, _, folio in result]
-    assert folios == ["11", "12", "13", "14", "15", "16", "17"]
-    # And the folio must be gone from the body.
+    page_printeds = [page_printed for _, _, page_printed in result]
+    assert page_printeds == ["11", "12", "13", "14", "15", "16", "17"]
+    # And the printed page number must be gone from the body.
     assert "11" not in result[0][1]
 
 
-def test_captures_roman_folio():
+def test_captures_roman_page_printed():
     import convert
     romans = ["i", "ii", "iii", "iv", "v", "vi"]
     pages = [(i + 1, f"Front matter {i}.\n{r}") for i, r in enumerate(romans)]
@@ -58,11 +59,11 @@ def test_captures_roman_folio():
     assert [f for _, _, f in result] == romans
 
 
-def test_page_with_no_folio_yields_none():
+def test_page_with_no_page_printed_yields_none():
     import convert
     pages = [(i, f"Body text page {i} with no page number.") for i in range(1, 8)]
     result = convert._strip_running_headers(pages)
-    assert all(folio is None for _, _, folio in result)
+    assert all(page_printed is None for _, _, page_printed in result)
 
 
 def test_short_document_early_return_still_three_tuples():
@@ -71,62 +72,62 @@ def test_short_document_early_return_still_three_tuples():
     pages = [(1, "Only one page."), (2, "Second page.")]
     result = convert._strip_running_headers(pages)
     assert all(len(t) == 3 for t in result)
-    assert all(folio is None for _, _, folio in result)
+    assert all(page_printed is None for _, _, page_printed in result)
 
 
 def test_pymupdf_emits_two_field_locator(tmp_path):
     import convert
     from tests import fixtures
 
-    pdf = fixtures.build_foliated_pdf(tmp_path, pages=8, offset=-4)
+    pdf = fixtures.build_page_printed_pdf(tmp_path, pages=8, offset=-4)
     out_dir = tmp_path / "out"
     out_dir.mkdir()
 
     report = convert.convert_with_pymupdf(pdf, out_dir)
     md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
 
-    # Sheet 5 carries printed folio 1.
-    assert "<!-- Page sheet=5 folio=1 -->" in md
-    assert "<!-- Page sheet=8 folio=4 -->" in md
-    # Sheets 1-4 have no printed folio.
-    assert "<!-- Page sheet=1 folio=none -->" in md
+    # PDF page 5 carries printed page number 1.
+    assert "<!-- page_pdf=5 page_printed=1 -->" in md
+    assert "<!-- page_pdf=8 page_printed=4 -->" in md
+    # PDF pages 1-4 have no printed page number.
+    assert "<!-- page_pdf=1 page_printed=none -->" in md
     # The old single-field format must be gone.
     assert "<!-- Page 5 -->" not in md
 
 
-def test_pymupdf_reports_folio_coverage(tmp_path):
+def test_pymupdf_reports_page_printed_coverage(tmp_path):
     import convert
     from tests import fixtures
 
-    pdf = fixtures.build_foliated_pdf(tmp_path, pages=8, offset=-4)
+    pdf = fixtures.build_page_printed_pdf(tmp_path, pages=8, offset=-4)
     out_dir = tmp_path / "out"
     out_dir.mkdir()
 
     report = convert.convert_with_pymupdf(pdf, out_dir)
-    assert report.total_locator_pages == 8
-    assert report.folio_pages == 4          # sheets 5,6,7,8
-    assert report.folio_coverage == pytest.approx(0.5)
-    assert report.locator_type == "printed"
+    assert report.page_locator_count == 8
+    assert report.page_printed_count == 4          # pdf pages 5,6,7,8
+    assert report.page_printed_coverage == pytest.approx(0.5)
+    assert report.page_numbering == "printed"
 
 
-def test_pymupdf_declares_sheet_only_when_no_folios(tmp_path):
-    """An ebook-derived PDF has no printed folio; it must say so."""
+def test_pymupdf_declares_pdf_only_when_no_page_printed(tmp_path):
+    """An ebook-derived PDF has no printed page number; it must say so."""
     import convert
     from tests import fixtures
 
-    pdf = fixtures.build_text_pdf(tmp_path, pages=6, body="No folio here.")
+    pdf = fixtures.build_text_pdf(tmp_path, pages=6, body="No page number here.")
     out_dir = tmp_path / "out"
     out_dir.mkdir()
 
     report = convert.convert_with_pymupdf(pdf, out_dir)
-    assert report.folio_pages == 0
-    assert report.locator_type == "sheet-only"
+    assert report.page_printed_count == 0
+    assert report.page_numbering == "pdf_only"
 
 
 def test_derive_offset_constant():
     import convert
     samples = {5: "1", 20: "16", 100: "96"}
-    offset, consistent = convert._derive_folio_offset(samples)
+    offset, consistent = convert._derive_page_offset(samples)
     assert offset == -4
     assert consistent is True
 
@@ -135,45 +136,45 @@ def test_derive_offset_inconsistent_is_rejected():
     """A book that renumbers partway through must not be interpolated."""
     import convert
     samples = {5: "1", 20: "16", 100: "40"}
-    offset, consistent = convert._derive_folio_offset(samples)
+    offset, consistent = convert._derive_page_offset(samples)
     assert consistent is False
 
 
-def test_derive_offset_ignores_roman_folios():
+def test_derive_offset_ignores_roman_page_printed():
     import convert
     samples = {2: "ii", 3: "iii", 10: "6", 20: "16", 30: "26"}
-    offset, consistent = convert._derive_folio_offset(samples)
+    offset, consistent = convert._derive_page_offset(samples)
     assert offset == -4
     assert consistent is True
 
 
 def test_derive_offset_needs_at_least_three_samples():
     import convert
-    offset, consistent = convert._derive_folio_offset({5: "1", 20: "16"})
+    offset, consistent = convert._derive_page_offset({5: "1", 20: "16"})
     assert consistent is False
 
 
-def test_interpolates_folio_on_unnumbered_pages(tmp_path):
-    """A page whose printed folio was lost to OCR still gets an address."""
+def test_interpolates_page_printed_on_unnumbered_pages(tmp_path):
+    """A page whose printed page number was lost to OCR still gets an address."""
     import convert
     from tests import fixtures
 
-    pdf = fixtures.build_foliated_pdf(tmp_path, pages=12, offset=-4)
+    pdf = fixtures.build_page_printed_pdf(tmp_path, pages=12, offset=-4)
     out_dir = tmp_path / "out"
     out_dir.mkdir()
     report = convert.convert_with_pymupdf(pdf, out_dir)
     md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
 
-    assert report.folio_offset == -4
-    assert report.folio_offset_consistent is True
-    # Sheets 1-4 are genuinely before page 1 — they must stay `none`,
-    # never a zero or negative folio.
-    assert "<!-- Page sheet=1 folio=none -->" in md
-    assert "folio=0" not in md
-    assert "folio=-" not in md
+    assert report.page_printed_offset == -4
+    assert report.page_printed_offset_consistent is True
+    # PDF pages 1-4 are genuinely before page 1 — they must stay `none`,
+    # never a zero or negative printed page number.
+    assert "<!-- page_pdf=1 page_printed=none -->" in md
+    assert "page_printed=0" not in md
+    assert "page_printed=-" not in md
 
 
-def test_derive_offset_tolerates_non_ascii_digit_folio():
+def test_derive_offset_tolerates_non_ascii_digit_page_printed():
     """A superscript footnote marker must not crash the conversion.
 
     `"²".isdigit()` is True but `int("²")` raises ValueError. The arabic
@@ -181,7 +182,7 @@ def test_derive_offset_tolerates_non_ascii_digit_folio():
     """
     import convert
     samples = {5: "²", 10: "6", 20: "16", 30: "26"}
-    offset, consistent = convert._derive_folio_offset(samples)
+    offset, consistent = convert._derive_page_offset(samples)
     assert offset == -4
     assert consistent is True
 
@@ -190,36 +191,36 @@ def test_derive_offset_ignores_arabic_indic_digits():
     import convert
     # U+0666 ARABIC-INDIC DIGIT SIX: isdigit() True, not ASCII decimal.
     samples = {5: "٦", 10: "6", 20: "16", 30: "26"}
-    offset, consistent = convert._derive_folio_offset(samples)
+    offset, consistent = convert._derive_page_offset(samples)
     assert offset == -4
     assert consistent is True
 
 
-def test_interpolates_missing_mid_body_folios(tmp_path):
-    """Sheets whose printed folio was lost to extraction get filled in."""
+def test_interpolates_missing_mid_body_page_printed(tmp_path):
+    """PDF pages whose printed page number was lost to extraction get filled in."""
     import convert
     from tests import fixtures
 
-    # Sheets 5-12 print folios 1-8; sheets 7 and 9 lost their footer.
-    pdf = fixtures.build_foliated_pdf(
-        tmp_path, pages=12, offset=-4, skip_folios_on=(7, 9)
+    # PDF pages 5-12 print page numbers 1-8; pages 7 and 9 lost their footer.
+    pdf = fixtures.build_page_printed_pdf(
+        tmp_path, pages=12, offset=-4, skip_page_printed_on=(7, 9)
     )
     out_dir = tmp_path / "out"
     out_dir.mkdir()
     report = convert.convert_with_pymupdf(pdf, out_dir)
     md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
 
-    assert report.folio_offset == -4
-    assert report.folio_offset_consistent is True
+    assert report.page_printed_offset == -4
+    assert report.page_printed_offset_consistent is True
     # The two gaps are interpolated to their true printed numbers.
-    assert "<!-- Page sheet=7 folio=3 -->" in md
-    assert "<!-- Page sheet=9 folio=5 -->" in md
-    # folio_pages counts CAPTURED folios only: sheets 5,6,8,10,11,12.
-    assert report.folio_pages == 6
-    # Front matter still refuses to invent a folio.
-    assert "<!-- Page sheet=1 folio=none -->" in md
-    assert "folio=0" not in md
-    assert "folio=-" not in md
+    assert "<!-- page_pdf=7 page_printed=3 -->" in md
+    assert "<!-- page_pdf=9 page_printed=5 -->" in md
+    # page_printed_count counts CAPTURED page numbers only: pdf pages 5,6,8,10,11,12.
+    assert report.page_printed_count == 6
+    # Front matter still refuses to invent a printed page number.
+    assert "<!-- page_pdf=1 page_printed=none -->" in md
+    assert "page_printed=0" not in md
+    assert "page_printed=-" not in md
 
 
 def test_no_extrapolation_past_the_last_captured_sample(tmp_path):
@@ -232,21 +233,21 @@ def test_no_extrapolation_past_the_last_captured_sample(tmp_path):
     import convert
     from tests import fixtures
 
-    # Sheets 5-12 print folios 1-8. Sheets 13-16 print nothing.
-    pdf = fixtures.build_foliated_pdf(
-        tmp_path, pages=16, offset=-4, skip_folios_on=(13, 14, 15, 16)
+    # PDF pages 5-12 print page numbers 1-8. PDF pages 13-16 print nothing.
+    pdf = fixtures.build_page_printed_pdf(
+        tmp_path, pages=16, offset=-4, skip_page_printed_on=(13, 14, 15, 16)
     )
     out_dir = tmp_path / "out"
     out_dir.mkdir()
     report = convert.convert_with_pymupdf(pdf, out_dir)
     md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
 
-    assert report.folio_offset == -4
-    assert report.folio_offset_consistent is True
-    for sheet in (13, 14, 15, 16):
-        assert f"<!-- Page sheet={sheet} folio=none -->" in md
+    assert report.page_printed_offset == -4
+    assert report.page_printed_offset_consistent is True
+    for page_pdf in (13, 14, 15, 16):
+        assert f"<!-- page_pdf={page_pdf} page_printed=none -->" in md
     # The would-be extrapolated numbers must appear nowhere.
-    for bad in ("folio=9", "folio=10", "folio=11", "folio=12"):
+    for bad in ("page_printed=9", "page_printed=10", "page_printed=11", "page_printed=12"):
         assert bad not in md
 
 
@@ -261,19 +262,19 @@ def test_renumbering_book_gets_no_interpolation_in_markdown(tmp_path):
     report = convert.convert_with_pymupdf(pdf, out_dir)
     md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
 
-    assert report.folio_offset_consistent is False
-    assert report.folio_offset is None
-    # Sheets 12 and 14 lost their printed number. With two disagreeing
+    assert report.page_printed_offset_consistent is False
+    assert report.page_printed_offset is None
+    # PDF pages 12 and 14 lost their printed number. With two disagreeing
     # numbering runs we must emit `none`, never a guess.
-    assert "<!-- Page sheet=12 folio=none -->" in md
-    assert "<!-- Page sheet=14 folio=none -->" in md
-    # Sheets 1-2 carry no printed number at all and stay `none`.
-    assert "<!-- Page sheet=1 folio=none -->" in md
-    assert "<!-- Page sheet=2 folio=none -->" in md
+    assert "<!-- page_pdf=12 page_printed=none -->" in md
+    assert "<!-- page_pdf=14 page_printed=none -->" in md
+    # PDF pages 1-2 carry no printed number at all and stay `none`.
+    assert "<!-- page_pdf=1 page_printed=none -->" in md
+    assert "<!-- page_pdf=2 page_printed=none -->" in md
 
 
 # ---------------------------------------------------------------------------
-# A number that merely TRAILS the last line was never printed as a folio.
+# A number that merely TRAILS the last line was never printed as a page number.
 # ---------------------------------------------------------------------------
 
 # Each page's closing sentence is DIFFERENT prose that happens to end in a
@@ -298,15 +299,15 @@ TRAILING_PROSE = [
 
 def _trailing_number_page(i):
     """Body whose last line is prose legitimately ending in a year."""
-    return f"Body text for sheet {i}.\n{TRAILING_PROSE[i - 1]} {1990 + i}"
+    return f"Body text for page {i}.\n{TRAILING_PROSE[i - 1]} {1990 + i}"
 
 
-def test_trailing_number_on_last_line_is_not_a_folio():
+def test_trailing_number_on_last_line_is_not_a_page_printed():
     """"...published in 1991" must not become printed page number 1991."""
     import convert
     pages = [(i, _trailing_number_page(i)) for i in range(1, 9)]
     result = convert._strip_running_headers(pages)
-    assert [folio for _, _, folio in result] == [None] * 8
+    assert [page_printed for _, _, page_printed in result] == [None] * 8
 
 
 def test_trailing_number_is_still_stripped_from_the_body():
@@ -321,34 +322,34 @@ def test_trailing_number_is_still_stripped_from_the_body():
 
 
 def test_trailing_number_does_not_poison_the_offset():
-    """A trailing year must not enter _derive_folio_offset at all.
+    """A trailing year must not enter _derive_page_offset at all.
 
-    With sheets 5-12 carrying real printed folios AND every page's prose
-    ending in a year, capturing the year would hand the derivation a set of
-    wildly disagreeing offsets and interpolation would be refused for the
-    whole book.
+    With PDF pages 5-12 carrying real printed page numbers AND every page's
+    prose ending in a year, capturing the year would hand the derivation a
+    set of wildly disagreeing offsets and interpolation would be refused
+    for the whole book.
     """
     import convert
     pages = []
     for i in range(1, 13):
         body = _trailing_number_page(i)
-        folio = i - 4
-        if folio >= 1:
-            body += f"\n{folio}"
+        page_printed = i - 4
+        if page_printed >= 1:
+            body += f"\n{page_printed}"
         pages.append((i, body))
 
     result = convert._strip_running_headers(pages)
-    folio_by_sheet = {s: f for s, _, f in result if f}
+    page_printed_by_pdf_index = {s: f for s, _, f in result if f}
     # Only the genuinely printed footers were captured.
-    assert folio_by_sheet == {5: "1", 6: "2", 7: "3", 8: "4", 9: "5",
-                              10: "6", 11: "7", 12: "8"}
-    offset, consistent = convert._derive_folio_offset(folio_by_sheet)
+    assert page_printed_by_pdf_index == {5: "1", 6: "2", 7: "3", 8: "4", 9: "5",
+                                          10: "6", 11: "7", 12: "8"}
+    offset, consistent = convert._derive_page_offset(page_printed_by_pdf_index)
     assert offset == -4
     assert consistent is True
 
 
-def test_trailing_number_pdf_emits_no_folios(tmp_path):
-    """End to end: a book with no printed folios must declare sheet-only."""
+def test_trailing_number_pdf_emits_no_page_printed(tmp_path):
+    """End to end: a book with no printed page numbers must declare pdf_only."""
     import convert
     from tests import fixtures
 
@@ -358,12 +359,12 @@ def test_trailing_number_pdf_emits_no_folios(tmp_path):
     report = convert.convert_with_pymupdf(pdf, out_dir)
     md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
 
-    assert report.folio_pages == 0
-    assert report.locator_type == "sheet-only"
-    for sheet in range(1, 9):
-        assert f"<!-- Page sheet={sheet} folio=none -->" in md
+    assert report.page_printed_count == 0
+    assert report.page_numbering == "pdf_only"
+    for page_pdf in range(1, 9):
+        assert f"<!-- page_pdf={page_pdf} page_printed=none -->" in md
     for year in range(1991, 1999):
-        assert f"folio={year}" not in md
+        assert f"page_printed={year}" not in md
 
 
 # ---------------------------------------------------------------------------
@@ -374,29 +375,29 @@ def test_trailing_number_pdf_emits_no_folios(tmp_path):
     "i", "ii", "iii", "iv", "v", "vi", "ix", "x", "xii", "xl", "lix", "Li",
     "XVIII", "cx",
 ])
-def test_is_roman_folio_accepts_real_numerals(value):
+def test_is_roman_page_number_accepts_real_numerals(value):
     import convert
-    assert convert._is_roman_folio(value) is True
+    assert convert._is_roman_page_number(value) is True
 
 
 @pytest.mark.parametrize("value", [
     "ill", "civil", "vill", "lil", "ivi", "", "iiii", "vv", "ic", "xx1",
 ])
-def test_is_roman_folio_rejects_english_words_and_malformed(value):
+def test_is_roman_page_number_rejects_english_words_and_malformed(value):
     import convert
-    assert convert._is_roman_folio(value) is False
+    assert convert._is_roman_page_number(value) is False
 
 
-def test_english_words_are_never_captured_as_folios():
-    """`ill` and `civil` match the loose stripping regex; neither is a folio."""
+def test_english_words_are_never_captured_as_page_printed():
+    """`ill` and `civil` match the loose stripping regex; neither is a printed page number."""
     import convert
     words = ["I", "ill", "civil", "ill", "civil", "I", "ill", "civil"]
     pages = [
-        (i, f"{words[i - 1]}\nBody text for sheet {i}.")
+        (i, f"{words[i - 1]}\nBody text for page {i}.")
         for i in range(1, 9)
     ]
     result = convert._strip_running_headers(pages)
-    assert [folio for _, _, folio in result] == [None] * 8
+    assert [page_printed for _, _, page_printed in result] == [None] * 8
 
 
 def test_english_words_are_still_stripped_from_the_body():
@@ -404,21 +405,21 @@ def test_english_words_are_still_stripped_from_the_body():
     import convert
     words = ["I", "ill", "civil", "ill", "civil", "I", "ill", "civil"]
     pages = [
-        (i, f"{words[i - 1]}\nBody text for sheet {i}.")
+        (i, f"{words[i - 1]}\nBody text for page {i}.")
         for i in range(1, 9)
     ]
     result = convert._strip_running_headers(pages)
     for i, (_, text, _) in enumerate(result, start=1):
-        assert text.strip() == f"Body text for sheet {i}."
+        assert text.strip() == f"Body text for page {i}."
 
 
 def test_a_single_roman_capture_is_not_believed():
     """One standalone `I` is the English pronoun far more often than page 1."""
     import convert
-    pages = [(i, f"Body text for sheet {i}.") for i in range(1, 9)]
-    pages[2] = (3, "I\nBody text for sheet 3.")
+    pages = [(i, f"Body text for page {i}.") for i in range(1, 9)]
+    pages[2] = (3, "I\nBody text for page 3.")
     result = convert._strip_running_headers(pages)
-    assert [folio for _, _, folio in result] == [None] * 8
+    assert [page_printed for _, _, page_printed in result] == [None] * 8
 
 
 def test_two_distinct_roman_captures_are_believed():
@@ -430,8 +431,8 @@ def test_two_distinct_roman_captures_are_believed():
     assert [f for _, _, f in result] == romans
 
 
-def test_wordlike_romans_do_not_flip_locator_type(tmp_path):
-    """A book with zero printed folios must not declare `printed`."""
+def test_wordlike_romans_do_not_flip_page_numbering(tmp_path):
+    """A book with zero printed page numbers must not declare `printed`."""
     import convert
     from tests import fixtures
 
@@ -440,22 +441,22 @@ def test_wordlike_romans_do_not_flip_locator_type(tmp_path):
     out_dir.mkdir()
     report = convert.convert_with_pymupdf(pdf, out_dir)
 
-    assert report.folio_pages == 0
-    assert report.locator_type == "sheet-only"
+    assert report.page_printed_count == 0
+    assert report.page_numbering == "pdf_only"
 
 
-def test_total_locator_pages_counts_only_emitted_locators(tmp_path):
+def test_page_locator_count_counts_only_emitted_locators(tmp_path):
     """The coverage denominator must not include pages that were skipped.
 
-    Sheets 6 and 10 are numbered-but-blank part-divider versos: they carry
-    a printed footer and nothing else, so they clean to empty and are
-    dropped before any locator is written. Counting them inflates the
-    denominator and under-reports folio_coverage.
+    PDF pages 6 and 10 are numbered-but-blank part-divider versos: they
+    carry a printed footer and nothing else, so they clean to empty and
+    are dropped before any locator is written. Counting them inflates the
+    denominator and under-reports page_printed_coverage.
     """
     import convert
     from tests import fixtures
 
-    pdf = fixtures.build_foliated_pdf(
+    pdf = fixtures.build_page_printed_pdf(
         tmp_path, pages=12, offset=-4, body_only_footer_on=(6, 10)
     )
     out_dir = tmp_path / "out"
@@ -463,36 +464,36 @@ def test_total_locator_pages_counts_only_emitted_locators(tmp_path):
     report = convert.convert_with_pymupdf(pdf, out_dir)
     md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
 
-    emitted = md.count("<!-- Page sheet=")
-    # The two footer-only sheets produced no locator at all.
+    emitted = md.count("<!-- page_pdf=")
+    # The two footer-only pages produced no locator at all.
     assert emitted == 10
-    assert "<!-- Page sheet=6 " not in md
-    assert "<!-- Page sheet=10 " not in md
-    assert report.total_locator_pages == emitted
-    # Both terms are counted over the SAME population. Sheets 5-12 all
+    assert "<!-- page_pdf=6 " not in md
+    assert "<!-- page_pdf=10 " not in md
+    assert report.page_locator_count == emitted
+    # Both terms are counted over the SAME population. PDF pages 5-12 all
     # carried a printed footer, but 6 and 10 never emitted a locator, so
-    # the numerator is 6 -- not the 8 folios that were captured.
-    assert report.folio_pages == 6
-    assert report.folio_coverage == pytest.approx(6 / 10)
-    assert report.folio_coverage <= 1.0
+    # the numerator is 6 -- not the 8 page numbers that were captured.
+    assert report.page_printed_count == 6
+    assert report.page_printed_coverage == pytest.approx(6 / 10)
+    assert report.page_printed_coverage <= 1.0
 
 
-def test_folio_coverage_never_exceeds_one(tmp_path):
+def test_page_printed_coverage_never_exceeds_one(tmp_path):
     """The ratio is a coverage fraction; >1.0 is meaningless by construction.
 
     Worth asserting outright because a >1.0 value is not merely wrong, it is
     wrong in the unsafe direction: it sails through the ingestion gate's
     `>= threshold` check while describing nothing real.
 
-    Every sheet that carries a printed folio here is also body-less, so it
-    is dropped before a locator is written. A numerator counted over
-    captured folios (8) against a denominator counted over emitted
-    locators (4) yields 2.0.
+    Every PDF page that carries a printed page number here is also
+    body-less, so it is dropped before a locator is written. A numerator
+    counted over captured page numbers (8) against a denominator counted
+    over emitted locators (4) yields 2.0.
     """
     import convert
     from tests import fixtures
 
-    pdf = fixtures.build_foliated_pdf(
+    pdf = fixtures.build_page_printed_pdf(
         tmp_path, pages=12, offset=-4,
         body_only_footer_on=tuple(range(5, 13)),
     )
@@ -501,33 +502,33 @@ def test_folio_coverage_never_exceeds_one(tmp_path):
     report = convert.convert_with_pymupdf(pdf, out_dir)
     md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
 
-    assert report.total_locator_pages == md.count("<!-- Page sheet=") == 4
-    assert report.folio_pages == 0
-    assert report.folio_coverage == 0.0
-    assert 0.0 <= report.folio_coverage <= 1.0
-    # A book whose every captured folio was dropped has no citable printed
-    # address left, and must not claim otherwise.
-    assert report.locator_type == "sheet-only"
+    assert report.page_locator_count == md.count("<!-- page_pdf=") == 4
+    assert report.page_printed_count == 0
+    assert report.page_printed_coverage == 0.0
+    assert 0.0 <= report.page_printed_coverage <= 1.0
+    # A book whose every captured page number was dropped has no citable
+    # printed address left, and must not claim otherwise.
+    assert report.page_numbering == "pdf_only"
 
 
-LOCATOR_TYPES = {"printed", "sheet-only", "none"}
+PAGE_NUMBERING_VALUES = {"printed", "pdf_only", "none"}
 
 
 @pytest.mark.parametrize("method,expected", [
     ("marker", "none"),
     ("pandoc", "none"),
     ("docling", "none"),
-    ("ocr", "sheet-only"),
-    ("pymupdf4llm", "sheet-only"),
+    ("ocr", "pdf_only"),
+    ("pymupdf4llm", "pdf_only"),
 ])
-def test_backend_locator_declarations(method, expected):
+def test_backend_page_numbering_declarations(method, expected):
     import convert
     report = convert.ConversionReport(
         source="in.pdf", output="out.md", method=method,
     )
-    convert._apply_backend_locator_type(report)
-    assert report.locator_type == expected
-    assert report.locator_type in LOCATOR_TYPES
+    convert._apply_backend_page_numbering(report)
+    assert report.page_numbering == expected
+    assert report.page_numbering in PAGE_NUMBERING_VALUES
 
 
 def test_pandoc_epub_conversion_writes_a_none_locator_sidecar(tmp_path):
@@ -555,13 +556,13 @@ def test_pandoc_epub_conversion_writes_a_none_locator_sidecar(tmp_path):
     # Pandoc now returns a ConversionReport like every other backend.
     assert isinstance(report, ConversionReport)
     assert report.method == "pandoc"
-    assert report.locator_type == "none"
+    assert report.page_numbering == "none"
 
     sidecar = out_dir / f"{epub.stem}.report.json"
     assert sidecar.exists()
     data = json.loads(sidecar.read_text(encoding="utf-8"))
     assert data["method"] == "pandoc"
-    assert data["locator_type"] == "none"
+    assert data["page_numbering"] == "none"
     # Page counts stay at their defaults; an epub has no pages to count.
     assert not data.get("total_pages")
 
@@ -584,7 +585,7 @@ def test_convert_book_epub_route_produces_a_sidecar(tmp_path):
     sidecar = out_dir / "dispatch.report.json"
     assert sidecar.exists()
     data = json.loads(sidecar.read_text(encoding="utf-8"))
-    assert data["locator_type"] == "none"
+    assert data["page_numbering"] == "none"
     # Cleanup is deliberately skipped on the epub route (it repairs PDF
     # extraction artifacts), so the sidecar must not claim it ran.
     assert not data.get("cleaned")

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -121,3 +121,53 @@ def test_pymupdf_declares_sheet_only_when_no_folios(tmp_path):
     report = convert.convert_with_pymupdf(pdf, out_dir)
     assert report.folio_pages == 0
     assert report.locator_type == "sheet-only"
+
+
+def test_derive_offset_constant():
+    import convert
+    samples = {5: "1", 20: "16", 100: "96"}
+    offset, consistent = convert._derive_folio_offset(samples)
+    assert offset == -4
+    assert consistent is True
+
+
+def test_derive_offset_inconsistent_is_rejected():
+    """A book that renumbers partway through must not be interpolated."""
+    import convert
+    samples = {5: "1", 20: "16", 100: "40"}
+    offset, consistent = convert._derive_folio_offset(samples)
+    assert consistent is False
+
+
+def test_derive_offset_ignores_roman_folios():
+    import convert
+    samples = {2: "ii", 3: "iii", 10: "6", 20: "16", 30: "26"}
+    offset, consistent = convert._derive_folio_offset(samples)
+    assert offset == -4
+    assert consistent is True
+
+
+def test_derive_offset_needs_at_least_three_samples():
+    import convert
+    offset, consistent = convert._derive_folio_offset({5: "1", 20: "16"})
+    assert consistent is False
+
+
+def test_interpolates_folio_on_unnumbered_pages(tmp_path):
+    """A page whose printed folio was lost to OCR still gets an address."""
+    import convert
+    from tests import fixtures
+
+    pdf = fixtures.build_foliated_pdf(tmp_path, pages=12, offset=-4)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
+
+    assert report.folio_offset == -4
+    assert report.folio_offset_consistent is True
+    # Sheets 1-4 are genuinely before page 1 — they must stay `none`,
+    # never a zero or negative folio.
+    assert "<!-- Page sheet=1 folio=none -->" in md
+    assert "folio=0" not in md
+    assert "folio=-" not in md

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -30,3 +30,45 @@ def test_report_locator_fields_round_trip(tmp_path):
     assert data["folio_pages"] == 20
     assert data["folio_offset"] == -12
     assert data["folio_offset_consistent"] is True
+
+
+def test_strip_running_headers_returns_three_tuples():
+    import convert
+    pages = [(i, f"Body text page {i}.\n{i + 10}") for i in range(1, 8)]
+    result = convert._strip_running_headers(pages)
+    assert all(len(t) == 3 for t in result)
+
+
+def test_captures_bottom_standalone_folio():
+    import convert
+    # Sheet i carries printed folio i+10 as a standalone bottom line.
+    pages = [(i, f"Body text for page {i}.\n{i + 10}") for i in range(1, 8)]
+    result = convert._strip_running_headers(pages)
+    folios = [folio for _, _, folio in result]
+    assert folios == ["11", "12", "13", "14", "15", "16", "17"]
+    # And the folio must be gone from the body.
+    assert "11" not in result[0][1]
+
+
+def test_captures_roman_folio():
+    import convert
+    romans = ["i", "ii", "iii", "iv", "v", "vi"]
+    pages = [(i + 1, f"Front matter {i}.\n{r}") for i, r in enumerate(romans)]
+    result = convert._strip_running_headers(pages)
+    assert [f for _, _, f in result] == romans
+
+
+def test_page_with_no_folio_yields_none():
+    import convert
+    pages = [(i, f"Body text page {i} with no page number.") for i in range(1, 8)]
+    result = convert._strip_running_headers(pages)
+    assert all(folio is None for _, _, folio in result)
+
+
+def test_short_document_early_return_still_three_tuples():
+    """The len < 5 early return must not leak 2-tuples to the caller."""
+    import convert
+    pages = [(1, "Only one page."), (2, "Second page.")]
+    result = convert._strip_running_headers(pages)
+    assert all(len(t) == 3 for t in result)
+    assert all(folio is None for _, _, folio in result)

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -270,3 +270,23 @@ def test_renumbering_book_gets_no_interpolation_in_markdown(tmp_path):
     # Sheets 1-2 carry no printed number at all and stay `none`.
     assert "<!-- Page sheet=1 folio=none -->" in md
     assert "<!-- Page sheet=2 folio=none -->" in md
+
+
+LOCATOR_TYPES = {"printed", "sheet-only", "none"}
+
+
+@pytest.mark.parametrize("method,expected", [
+    ("marker", "none"),
+    ("pandoc", "none"),
+    ("docling", "none"),
+    ("ocr", "sheet-only"),
+    ("pymupdf4llm", "sheet-only"),
+])
+def test_backend_locator_declarations(method, expected):
+    import convert
+    report = convert.ConversionReport(
+        source="in.pdf", output="out.md", method=method,
+    )
+    convert._apply_backend_locator_type(report)
+    assert report.locator_type == expected
+    assert report.locator_type in LOCATOR_TYPES

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -72,3 +72,52 @@ def test_short_document_early_return_still_three_tuples():
     result = convert._strip_running_headers(pages)
     assert all(len(t) == 3 for t in result)
     assert all(folio is None for _, _, folio in result)
+
+
+def test_pymupdf_emits_two_field_locator(tmp_path):
+    import convert
+    from tests import fixtures
+
+    pdf = fixtures.build_foliated_pdf(tmp_path, pages=8, offset=-4)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
+
+    # Sheet 5 carries printed folio 1.
+    assert "<!-- Page sheet=5 folio=1 -->" in md
+    assert "<!-- Page sheet=8 folio=4 -->" in md
+    # Sheets 1-4 have no printed folio.
+    assert "<!-- Page sheet=1 folio=none -->" in md
+    # The old single-field format must be gone.
+    assert "<!-- Page 5 -->" not in md
+
+
+def test_pymupdf_reports_folio_coverage(tmp_path):
+    import convert
+    from tests import fixtures
+
+    pdf = fixtures.build_foliated_pdf(tmp_path, pages=8, offset=-4)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    assert report.total_locator_pages == 8
+    assert report.folio_pages == 4          # sheets 5,6,7,8
+    assert report.folio_coverage == pytest.approx(0.5)
+    assert report.locator_type == "printed"
+
+
+def test_pymupdf_declares_sheet_only_when_no_folios(tmp_path):
+    """An ebook-derived PDF has no printed folio; it must say so."""
+    import convert
+    from tests import fixtures
+
+    pdf = fixtures.build_text_pdf(tmp_path, pages=6, body="No folio here.")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    assert report.folio_pages == 0
+    assert report.locator_type == "sheet-only"

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -272,6 +272,208 @@ def test_renumbering_book_gets_no_interpolation_in_markdown(tmp_path):
     assert "<!-- Page sheet=2 folio=none -->" in md
 
 
+# ---------------------------------------------------------------------------
+# A number that merely TRAILS the last line was never printed as a folio.
+# ---------------------------------------------------------------------------
+
+# Each page's closing sentence is DIFFERENT prose that happens to end in a
+# number. Identical closing lines would be caught earlier as a repeating
+# running-footer pattern and removed whole, never reaching the trailing
+# number branch this section exists to pin down.
+TRAILING_PROSE = [
+    "The study was published in",
+    "The print run sold roughly",
+    "The trial ran for",
+    "The firm employed some",
+    "The division grew to",
+    "The strike lasted about",
+    "The audience reached nearly",
+    "The revision shipped in",
+    "The survey covered exactly",
+    "The programme spanned some",
+    "The refit cost about",
+    "The agency hired around",
+]
+
+
+def _trailing_number_page(i):
+    """Body whose last line is prose legitimately ending in a year."""
+    return f"Body text for sheet {i}.\n{TRAILING_PROSE[i - 1]} {1990 + i}"
+
+
+def test_trailing_number_on_last_line_is_not_a_folio():
+    """"...published in 1991" must not become printed page number 1991."""
+    import convert
+    pages = [(i, _trailing_number_page(i)) for i in range(1, 9)]
+    result = convert._strip_running_headers(pages)
+    assert [folio for _, _, folio in result] == [None] * 8
+
+
+def test_trailing_number_is_still_stripped_from_the_body():
+    """Capture goes away; the stripping behavior must not change."""
+    import convert
+    pages = [(i, _trailing_number_page(i)) for i in range(1, 9)]
+    result = convert._strip_running_headers(pages)
+    for i, (_, text, _) in enumerate(result, start=1):
+        # The prose survives; only the trailing number is removed.
+        assert text.rstrip().endswith(TRAILING_PROSE[i - 1])
+        assert str(1990 + i) not in text
+
+
+def test_trailing_number_does_not_poison_the_offset():
+    """A trailing year must not enter _derive_folio_offset at all.
+
+    With sheets 5-12 carrying real printed folios AND every page's prose
+    ending in a year, capturing the year would hand the derivation a set of
+    wildly disagreeing offsets and interpolation would be refused for the
+    whole book.
+    """
+    import convert
+    pages = []
+    for i in range(1, 13):
+        body = _trailing_number_page(i)
+        folio = i - 4
+        if folio >= 1:
+            body += f"\n{folio}"
+        pages.append((i, body))
+
+    result = convert._strip_running_headers(pages)
+    folio_by_sheet = {s: f for s, _, f in result if f}
+    # Only the genuinely printed footers were captured.
+    assert folio_by_sheet == {5: "1", 6: "2", 7: "3", 8: "4", 9: "5",
+                              10: "6", 11: "7", 12: "8"}
+    offset, consistent = convert._derive_folio_offset(folio_by_sheet)
+    assert offset == -4
+    assert consistent is True
+
+
+def test_trailing_number_pdf_emits_no_folios(tmp_path):
+    """End to end: a book with no printed folios must declare sheet-only."""
+    import convert
+    from tests import fixtures
+
+    pdf = fixtures.build_trailing_number_pdf(tmp_path, pages=8)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
+
+    assert report.folio_pages == 0
+    assert report.locator_type == "sheet-only"
+    for sheet in range(1, 9):
+        assert f"<!-- Page sheet={sheet} folio=none -->" in md
+    for year in range(1991, 1999):
+        assert f"folio={year}" not in md
+
+
+# ---------------------------------------------------------------------------
+# The roman path: real numerals only, and never on a single sighting.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", [
+    "i", "ii", "iii", "iv", "v", "vi", "ix", "x", "xii", "xl", "lix", "Li",
+    "XVIII", "cx",
+])
+def test_is_roman_folio_accepts_real_numerals(value):
+    import convert
+    assert convert._is_roman_folio(value) is True
+
+
+@pytest.mark.parametrize("value", [
+    "ill", "civil", "vill", "lil", "ivi", "", "iiii", "vv", "ic", "xx1",
+])
+def test_is_roman_folio_rejects_english_words_and_malformed(value):
+    import convert
+    assert convert._is_roman_folio(value) is False
+
+
+def test_english_words_are_never_captured_as_folios():
+    """`ill` and `civil` match the loose stripping regex; neither is a folio."""
+    import convert
+    words = ["I", "ill", "civil", "ill", "civil", "I", "ill", "civil"]
+    pages = [
+        (i, f"{words[i - 1]}\nBody text for sheet {i}.")
+        for i in range(1, 9)
+    ]
+    result = convert._strip_running_headers(pages)
+    assert [folio for _, _, folio in result] == [None] * 8
+
+
+def test_english_words_are_still_stripped_from_the_body():
+    """Capture narrows; stripping stays exactly as it was."""
+    import convert
+    words = ["I", "ill", "civil", "ill", "civil", "I", "ill", "civil"]
+    pages = [
+        (i, f"{words[i - 1]}\nBody text for sheet {i}.")
+        for i in range(1, 9)
+    ]
+    result = convert._strip_running_headers(pages)
+    for i, (_, text, _) in enumerate(result, start=1):
+        assert text.strip() == f"Body text for sheet {i}."
+
+
+def test_a_single_roman_capture_is_not_believed():
+    """One standalone `I` is the English pronoun far more often than page 1."""
+    import convert
+    pages = [(i, f"Body text for sheet {i}.") for i in range(1, 9)]
+    pages[2] = (3, "I\nBody text for sheet 3.")
+    result = convert._strip_running_headers(pages)
+    assert [folio for _, _, folio in result] == [None] * 8
+
+
+def test_two_distinct_roman_captures_are_believed():
+    """A genuine front-matter run corroborates itself."""
+    import convert
+    romans = ["i", "ii", "iii", "iv", "v", "vi"]
+    pages = [(i + 1, f"Front matter {i}.\n{r}") for i, r in enumerate(romans)]
+    result = convert._strip_running_headers(pages)
+    assert [f for _, _, f in result] == romans
+
+
+def test_wordlike_romans_do_not_flip_locator_type(tmp_path):
+    """A book with zero printed folios must not declare `printed`."""
+    import convert
+    from tests import fixtures
+
+    pdf = fixtures.build_roman_wordlike_pdf(tmp_path)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+
+    assert report.folio_pages == 0
+    assert report.locator_type == "sheet-only"
+
+
+def test_total_locator_pages_counts_only_emitted_locators(tmp_path):
+    """The coverage denominator must not include pages that were skipped.
+
+    Sheets 6 and 10 are numbered-but-blank part-divider versos: they carry
+    a printed footer and nothing else, so they clean to empty and are
+    dropped before any locator is written. Counting them inflates the
+    denominator and under-reports folio_coverage.
+    """
+    import convert
+    from tests import fixtures
+
+    pdf = fixtures.build_foliated_pdf(
+        tmp_path, pages=12, offset=-4, body_only_footer_on=(6, 10)
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
+
+    emitted = md.count("<!-- Page sheet=")
+    # The two footer-only sheets produced no locator at all.
+    assert emitted == 10
+    assert "<!-- Page sheet=6 " not in md
+    assert "<!-- Page sheet=10 " not in md
+    assert report.total_locator_pages == emitted
+    assert report.folio_coverage == pytest.approx(
+        report.folio_pages / emitted
+    )
+
+
 LOCATOR_TYPES = {"printed", "sheet-only", "none"}
 
 

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -1,0 +1,32 @@
+"""Tests for typed page locators: sheet index + printed folio capture."""
+import json
+from pathlib import Path
+
+import pytest
+
+from report import ConversionReport, write_report
+
+
+def test_report_defaults_to_no_locator():
+    r = ConversionReport(source="in.pdf", output="out.md", method="pymupdf")
+    assert r.locator_type == "none"
+    assert r.folio_pages == 0
+    assert r.total_locator_pages == 0
+    assert r.folio_coverage == 0.0
+    assert r.folio_offset is None
+    assert r.folio_offset_consistent is False
+
+
+def test_report_locator_fields_round_trip(tmp_path):
+    r = ConversionReport(
+        source="in.pdf", output="out.md", method="pymupdf",
+        locator_type="printed", folio_pages=20, total_locator_pages=319,
+        folio_coverage=0.0627, folio_offset=-12, folio_offset_consistent=True,
+    )
+    p = tmp_path / "out.report.json"
+    write_report(p, r)
+    data = json.loads(p.read_text(encoding="utf-8"))
+    assert data["locator_type"] == "printed"
+    assert data["folio_pages"] == 20
+    assert data["folio_offset"] == -12
+    assert data["folio_offset_consistent"] is True


### PR DESCRIPTION
## The problem

BookConvert emitted `<!-- Page N -->` where N was the **PDF page index**, and downstream that was being read as a **printed page number**. Those are different things — sheet 59 of a PDF is often printed page 47.

Separately, `_strip_running_headers()` was *deleting* the printed page number as noise on every conversion, discarding the one address valid for citation.

And three of six backends emitted no markers at all, silently — which is why the loss went unnoticed for months across a 780-source research corpus.

## What this does

Emits both addresses and declares which exist:

```
<!-- page_pdf=59 page_printed=47 -->      a real printed page number
<!-- page_pdf=59 page_printed=none -->    none in the source
```

Every backend now declares `page_numbering` (`printed` | `pdf_only` | `none`) plus coverage in its `.report.json`, so a downstream ingestion gate can route away from a backend that can't produce a citable address instead of discovering the loss later. `pandoc` (EPUB) previously wrote no sidecar at all; it does now.

Because captures are sparse — Grove's 319-page scan yielded ~20 readable numbers — printed page numbers are interpolated across gaps, but only under guards that fail closed: at least 3 agreeing samples, unanimous offset, clamped strictly *between* the first and last captured sample, roman front matter excluded, never a page below 1. Any ambiguity refuses the whole book rather than guessing.

## Governing value

**Never present a page number that is not the one printed on that page.** A wrong citation misleads a reader who checks it, and they cannot tell. Every design choice here prefers emitting `none` over emitting a guess.

## Verification

Old-vs-new differential over **3,720 real pages from 20 archive books**:

- **0 cleaned-text differences** — the stripping behavior the 172 existing conversions depend on is provably unchanged.
- **11 bogus captures removed**, all garbage the old code was publishing as page numbers: chapter numbers lifted off "chapter N" headings, a printer's key `10 9 8 7…` read as page 1, a standalone `c` read as roman 100, a lowercase `l` read as roman 50.

End-to-end on real books:

| Book | `page_numbering` | count | coverage |
|---|---|---|---|
| *Give and Take* | `printed` | 528/528 | 1.00 |
| *Deep Work* (no printed numbers anywhere) | `pdf_only` | 0 | 0.00 |

Suite: 94 → 156 passing, 0 failures.

## Review history

Six task reviews plus an adversarial whole-branch review. The whole-branch pass found 1 Critical + 2 Important that no per-task review could see — most importantly that a number trailing the last line was being captured as a page number, so a page ending "…published in 1999" emitted `1999`. All fixed and mutation-verified.

## Breaking change

`<!-- Page N -->` → `<!-- page_pdf=N page_printed=X -->`. The known consumer, `mc-wiki/tools/wiki-maintain.py`, matches the old regex and will report `0` markers rather than erroring. Its paired fix is PR 2 of this bet. Already-converted files keep the old format, so the corpus is mixed and consumers must accept both.

## Context

PR 1 of 3. Design + investigation: management-craft `docs/2B-PROJECTS/page-locator-pipeline/v1/RESEARCH.md`. PR 2 adds the ingestion gate in mc-wiki; PR 3 adds MC's citation surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)