### PR TITLE
feat(marker): emit typed page locators instead of declaring scans uncitable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,14 @@ output/**/*.txt
 
 # Subagent-driven-development scratch (ledger, briefs, review packages)
 .superpowers/
+
+# Conversion artifacts. `output/**/*.md` alone was not enough: a `git add -A`
+# also swept in sidecar reports, extracted images, run logs, and the archived
+# source books. Each user generates their own.
+output/**/*.report.json
+output/**/*.png
+output/**/*.jpg
+output/**/*.jpeg
+output/**/*.json
+archive/
+logs/

--- a/convert.py
+++ b/convert.py
@@ -23,6 +23,7 @@ Usage:
 
 import argparse
 import collections
+import io
 import logging
 import os
 import shlex
@@ -933,11 +934,16 @@ def _derive_page_offset(page_printed_by_pdf_index):
     """Derive a constant page_pdf->page_printed offset from captured samples.
 
     Returns (offset, is_consistent). `offset` is page_printed - page_pdf.
-    Consistency requires at least 3 arabic samples that all agree; a book
-    that renumbers partway through (part-openers restarting at 1,
-    roman-to-arabic front matter) will disagree, and we refuse to
-    interpolate rather than invent page numbers. Roman page numbers never
+    Consistency requires at least 3 arabic samples that overwhelmingly
+    agree; a book that renumbers partway through (part-openers restarting
+    at 1, roman-to-arabic front matter) will disagree in a way this refuses,
+    rather than inventing page numbers. Roman page numbers never
     participate — they belong to a separate numbering sequence.
+
+    Unanimity is not special-cased: a unanimous set is simply one with 100%
+    agreement and no dissenters, so `_dominant_page_offset` returns it by
+    the same path. Callers that need to know WHICH samples dissented use
+    `_page_offset_outliers`.
 
     Args:
         page_printed_by_pdf_index: dict of PDF page index -> printed page
@@ -946,25 +952,86 @@ def _derive_page_offset(page_printed_by_pdf_index):
     Returns:
         (int | None, bool)
     """
-    offsets = [
-        int(page_printed) - page_pdf
+    by_index = {
+        page_pdf: int(page_printed) - page_pdf
         for page_pdf, page_printed in page_printed_by_pdf_index.items()
         if _is_arabic_page_number(page_printed)
-    ]
-    if len(offsets) < 3:
+    }
+    if len(by_index) < 3:
         return (None, False)
-    if len(set(offsets)) == 1:
-        return (offsets[0], True)
-    return (None, False)
+    dominant = _dominant_page_offset(by_index)
+    return (dominant, True) if dominant is not None else (None, False)
 
 
-# What kind of page address each backend can produce. `pymupdf` is absent
-# because it decides at runtime (printed when printed page numbers were
-# captured, pdf_only otherwise) — see convert_with_pymupdf.
+# A lone sample disagreeing with hundreds of others is an OCR misread of one
+# digit, not evidence that the book renumbers. Boyatzis printed 9 and 39 on
+# two pages that marker read as "0" and "30"; under strict unanimity those
+# two misreads both blocked interpolation for 42 other pages AND were
+# published verbatim as page numbers — the exact harm the locator work
+# exists to prevent.
+#
+# Rejecting an outlier is only safe when the consensus is overwhelming and
+# the dissent is scattered. A book that genuinely renumbers (endnotes
+# restarting at 1, a second sequence after an insert) produces a CONTIGUOUS
+# RUN of samples at the new offset, never isolated singletons. That
+# distinction is what keeps this from silently flattening a real second
+# numbering sequence into a wrong one.
+# This threshold also sets the floor on sample size: any dissent at all
+# needs 20+ samples to stay above 0.95 (d/n <= 0.05), so a separate
+# minimum-samples guard would be unreachable and is deliberately absent
+# rather than sitting here implying protection it never provides.
+_OFFSET_CONSENSUS_MIN_AGREEMENT = 0.95
+# Two dissenters within this many sheets of each other count as a run.
+_OFFSET_DISSENT_RUN_GAP = 2
+
+
+def _dominant_page_offset(offset_by_pdf_index):
+    """Return the consensus offset, or None if the disagreement is real.
+
+    Args:
+        offset_by_pdf_index: dict of PDF page index -> (printed - pdf)
+
+    Returns:
+        int | None
+    """
+    counts = collections.Counter(offset_by_pdf_index.values())
+    dominant, agreeing = counts.most_common(1)[0]
+    total = len(offset_by_pdf_index)
+    if agreeing / total < _OFFSET_CONSENSUS_MIN_AGREEMENT:
+        return None
+    dissenters = sorted(i for i, o in offset_by_pdf_index.items() if o != dominant)
+    # Any two dissenters close together are a numbering change, not noise.
+    for earlier, later in zip(dissenters, dissenters[1:]):
+        if later - earlier <= _OFFSET_DISSENT_RUN_GAP:
+            return None
+    return dominant
+
+
+def _page_offset_outliers(page_printed_by_pdf_index, offset):
+    """PDF page indices whose captured folio contradicts the derived offset.
+
+    These are misreads. They must be suppressed rather than emitted: a
+    captured value is normally the most trustworthy kind of address, so a
+    corrupted one is published with full confidence and a reader cannot tell.
+    Suppressing lets interpolation supply the right number instead.
+    """
+    if offset is None:
+        return set()
+    return {
+        page_pdf
+        for page_pdf, page_printed in page_printed_by_pdf_index.items()
+        if _is_arabic_page_number(page_printed)
+        and int(page_printed) - page_pdf != offset
+    }
+
+
+# What kind of page address each backend can produce. `pymupdf` and `marker`
+# are absent because they decide at runtime (printed when printed page
+# numbers were captured, pdf_only otherwise) — see convert_with_pymupdf and
+# convert_with_marker.
 BACKEND_PAGE_NUMBERING = {
     "ocr": "pdf_only",
     "pymupdf4llm": "pdf_only",
-    "marker": "none",
     "pandoc": "none",
     "docling": "none",
 }
@@ -981,6 +1048,207 @@ def _apply_backend_page_numbering(report):
     if fixed:
         report.page_numbering = fixed
     return report
+
+
+# --- marker page locators --------------------------------------------------
+#
+# marker is the only backend that works on a scanned book: pymupdf needs a
+# text layer the scan does not have, and tesseract has no table handling.
+# So marker is precisely the backend a home-scanned print book depends on,
+# and it was the one declaring `page_numbering: "none"`.
+#
+# marker already reads the printed page number — it classifies the running
+# head as a PageHeader block and then discards it. Three renderer flags
+# recover it: `--paginate_output` emits a `{N}-----` separator per page, and
+# `--keep_pageheader_in_output` / `--keep_pagefooter_in_output` stop the
+# furniture being dropped. We request all three, capture the folio, and strip
+# the furniture back out.
+#
+# Both bands are required. Book designers put a running head carrying the
+# folio on ordinary pages but a *drop folio* at the foot of chapter openers
+# and full-page tables — exactly the pages a statistical appendix consists
+# of. Reading only the head captured 0 folios across Boyatzis's entire
+# appendix while appearing to work.
+#
+# A rejected alternative: leave marker in its default configuration and read
+# folios independently, by OCRing a crop of each page's margins. That makes
+# the body provably untouched, which is why it was tried — but a blind crop
+# cannot tell a page number from a table cell. On Boyatzis it captured 237
+# folios to marker's 288, and the appendix (full-page statistical tables)
+# polluted the samples so badly that no offset could be derived at all: the
+# book would have ended up with NO interpolated page numbers and 33 wrong
+# captured ones. marker's layout model knows what a running head is; a
+# rectangle does not.
+#
+# The separator carries marker's own page index, so pages that produce no
+# text still advance the count — the address never drifts.
+
+MARKER_LOCATOR_ARGS = (
+    "--paginate_output",
+    "--keep_pageheader_in_output",
+    "--keep_pagefooter_in_output",
+)
+
+# marker's page separator: "{58}------------------------------------------------"
+_MARKER_PAGE_SEPARATOR_RE = re.compile(r'^\{(\d+)\}-{2,}\s*$')
+
+# A folio standing alone on its line. Arabic is capped at 4 digits so a year
+# ("1982") that survived into the band is admitted here and then rejected by
+# the offset check, rather than silently reinterpreted as a page number.
+_MARKER_FOLIO_RE = re.compile(r'^(\d{1,4})$')
+
+# A markdown heading is content, never page furniture. marker renders
+# furniture as plain text, so a `#` line is by definition not a running head.
+_MARKDOWN_HEADING_RE = re.compile(r'^#{1,6}\s')
+
+# How many leading (or trailing) lines of a page may be furniture. A running
+# head is one or two lines — a title and a folio; anything deeper is body.
+_MARKER_HEADER_SCAN_LINES = 3
+
+# How many pages a line must recur on before it counts as furniture. Verso
+# and recto usually carry different heads, so a book alternates between two.
+_MARKER_HEADER_MIN_REPEATS = 3
+
+
+def _split_marker_pages(text):
+    """Split paginated marker output into (page_index, page_text) pairs.
+
+    Returns None when the text carries no separators at all, which means
+    marker ran without `--paginate_output` and no page addressing is
+    possible. Callers must treat that as "no locators", never as page 0.
+    """
+    lines = text.split('\n')
+    pages, current, index = [], [], None
+    for line in lines:
+        m = _MARKER_PAGE_SEPARATOR_RE.match(line)
+        if m:
+            if index is not None:
+                pages.append((index, '\n'.join(current)))
+            index, current = int(m.group(1)), []
+            continue
+        current.append(line)
+    if index is None:
+        return None
+    pages.append((index, '\n'.join(current)))
+    return pages
+
+
+def _is_marker_folio(line):
+    """Whether a line is shaped like a printed page number.
+
+    Arabic zero is rejected outright: no book prints page 0, so a captured
+    "0" is always a misread (Boyatzis's page 9, on a scan). That is a
+    validity check, not a judgment call — unlike the consensus rule, it needs
+    no evidence from the rest of the book.
+    """
+    m = _MARKER_FOLIO_RE.match(line)
+    if m:
+        return int(m.group(1)) >= 1
+    return bool(_is_roman_page_number(line))
+
+
+def _band_lines(page_text, from_end=False):
+    """First (or last) few non-empty lines of a page, in reading order."""
+    lines = [l for l in page_text.split('\n') if l.strip()]
+    return lines[-_MARKER_HEADER_SCAN_LINES:] if from_end else lines[:_MARKER_HEADER_SCAN_LINES]
+
+
+def _marker_recurring_lines(pages, from_end=False):
+    """Return the lines that recur often enough to be page furniture.
+
+    Frequency is the discriminator that makes stripping safe. A book's
+    running head appears on many pages; a first line of body prose appears
+    once. Requiring recurrence means an unusual opening sentence is never
+    mistaken for furniture, at the cost of leaving a head that genuinely
+    appears twice — the safe direction to err, since a stray head in the body
+    is visible while deleted body text is not.
+    """
+    counts = collections.Counter()
+    for _index, page in pages:
+        seen = set()
+        for line in _band_lines(page, from_end):
+            stripped = line.strip()
+            # Folios differ every page, so they never recur; they are matched
+            # by shape, not by frequency.
+            if stripped and not _is_marker_folio(stripped):
+                seen.add(stripped)
+        counts.update(seen)
+    return {line for line, n in counts.items() if n >= _MARKER_HEADER_MIN_REPEATS}
+
+
+def _strip_marker_page_furniture(page_text, header_lines, footer_lines):
+    """Remove running head and foot from one page, returning (folio, body).
+
+    Each band is consumed from its own end and stops at the first line that
+    is neither known furniture nor a bare folio — the moment body text
+    starts, stripping stops.
+
+    Capture and stripping are deliberately decoupled. Capture scans the whole
+    band, so a folio sitting *behind* an unrecognised head line is still
+    read; stripping removes only lines it positively recognises. They can
+    therefore disagree — a folio may be captured and left in the body — and
+    that is the safe direction: a stray number in the text is visible,
+    whereas deleting a line that turned out to be prose is not.
+    """
+    lines = page_text.split('\n')
+
+    def first_folio(band):
+        for line in band:
+            if _is_marker_folio(line.strip()):
+                return line.strip()
+        return None
+
+    folio = (first_folio(_band_lines(page_text))
+             or first_folio(_band_lines(page_text, from_end=True)))
+
+    def strippable(line, known):
+        stripped = line.strip()
+        if _MARKDOWN_HEADING_RE.match(stripped):
+            return False
+        return _is_marker_folio(stripped) or stripped in known
+
+    start, consumed = 0, 0
+    while start < len(lines) and consumed < _MARKER_HEADER_SCAN_LINES:
+        if not lines[start].strip():
+            start += 1
+        elif strippable(lines[start], header_lines):
+            start += 1
+            consumed += 1
+        else:
+            break
+
+    end, consumed = len(lines), 0
+    while end > start and consumed < _MARKER_HEADER_SCAN_LINES:
+        if not lines[end - 1].strip():
+            end -= 1
+        elif strippable(lines[end - 1], footer_lines):
+            end -= 1
+            consumed += 1
+        else:
+            break
+
+    return folio, '\n'.join(lines[start:end]).strip('\n')
+
+
+def _marker_page_locators(text):
+    """Capture printed page numbers from paginated marker output.
+
+    Returns (pages, page_printed_by_index) where `pages` is a list of
+    (page_index, body_text) with page furniture removed, or (None, {}) when
+    the output was not paginated.
+    """
+    pages = _split_marker_pages(text)
+    if pages is None:
+        return None, {}
+    header_lines = _marker_recurring_lines(pages, from_end=False)
+    footer_lines = _marker_recurring_lines(pages, from_end=True)
+    cleaned, printed = [], {}
+    for index, page in pages:
+        folio, body = _strip_marker_page_furniture(page, header_lines, footer_lines)
+        if folio:
+            printed[index] = folio
+        cleaned.append((index, body))
+    return cleaned, printed
 
 
 def _merge_split_caps_headings(lines):
@@ -2644,6 +2912,82 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
     return report
 
 
+def _rewrite_marker_page_locators(target, report):
+    """Replace marker's page separators with typed locator comments.
+
+    Rewrites `{58}-----` into `<!-- page_pdf=58 page_printed=43 -->`, having
+    stripped the running head and foot the locator flags asked marker to keep.
+
+    Interpolation follows the same rules as the pymupdf path and for the same
+    reason: printed numbers are captured sparsely (a chapter opener or a
+    full-page table often shows none), and a gap between two agreeing samples
+    is safe to fill while anything outside that span is a guess. Ambiguity
+    refuses the whole book rather than inventing an address a reader cannot
+    check.
+
+    A no-op when the output is not paginated, which is what happens if a
+    caller overrides the locator flags through `--marker-args`.
+    """
+    text = target.read_text(encoding="utf-8", errors="replace")
+    pages, page_printed_by_index = _marker_page_locators(text)
+    if pages is None:
+        report.page_numbering = "none"
+        report.warnings.append(
+            "marker output was not paginated, so no page locators were "
+            "emitted; the source cannot be cited by page"
+        )
+        return
+
+    offset, offset_consistent = _derive_page_offset(page_printed_by_index)
+    # Captured-but-contradicting folios are OCR misreads. Drop them so
+    # interpolation can supply the right number, and so the span below is
+    # not stretched by a corrupted sample.
+    misread = _page_offset_outliers(page_printed_by_index, offset if offset_consistent else None)
+    for index in misread:
+        report.warnings.append(
+            f"page_pdf={index}: captured printed page "
+            f"'{page_printed_by_index[index]}' contradicts the book's "
+            f"offset {offset:+d}; treated as an OCR misread and replaced "
+            f"by the interpolated value"
+        )
+        del page_printed_by_index[index]
+
+    arabic = _arabic_page_pdf_indices(page_printed_by_index)
+    span = (min(arabic), max(arabic)) if arabic else None
+
+    out = []
+    emitted = captured = 0
+    for index, body in pages:
+        printed = page_printed_by_index.get(index)
+        effective = printed
+        if (effective is None
+                and offset_consistent
+                and span is not None
+                and span[0] <= index <= span[1]):
+            candidate = index + offset
+            if candidate >= 1:
+                effective = str(candidate)
+        out.append(f"<!-- page_pdf={index} page_printed={effective or 'none'} -->\n")
+        emitted += 1
+        if printed:
+            captured += 1
+        if body.strip():
+            out.append('\n' + body.strip('\n') + '\n\n')
+        else:
+            out.append('\n')
+    target.write_text(''.join(out), encoding="utf-8")
+
+    report.page_locator_count = emitted
+    report.page_printed_count = captured
+    report.page_printed_coverage = captured / emitted if emitted else 0.0
+    report.page_numbering = "printed" if captured else "pdf_only"
+    report.page_printed_offset = offset
+    report.page_printed_offset_consistent = offset_consistent
+    print(f"  page locators: {emitted} pages, {captured} printed numbers "
+          f"captured, coverage {report.page_printed_coverage:.2f}"
+          + (f", offset {offset:+d}" if offset_consistent else ", offset inconsistent"))
+
+
 def convert_with_marker(pdf_path, output_dir, marker_args=None):
     """Convert a text-based PDF using Marker.
 
@@ -2660,6 +3004,10 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None):
         # `--output_dir` flag rather than as a second positional argument.
         # Passing it positionally raises "Got unexpected extra argument".
         cmd = ["marker_single", str(pdf_path), "--output_dir", tmpdir]
+        # Page-locator flags go on unconditionally: a source filed without a
+        # citable address cannot be fixed later without reconverting, and
+        # marker is the only backend that works on a scanned book.
+        cmd.extend(MARKER_LOCATOR_ARGS)
         if marker_args:
             cmd.extend(marker_args)
             print(f"  extra marker args: {' '.join(marker_args)}")
@@ -2749,6 +3097,7 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None):
                 report.total_pages = len(src)
         except Exception as e:
             report.warnings.append(f"could not read page count: {e}")
+        _rewrite_marker_page_locators(target, report)
         apply_table_signals(report, target)
         print(
             f"  tables: {report.tables_emitted} emitted / "

--- a/tests/test_marker_page_locators.py
+++ b/tests/test_marker_page_locators.py
@@ -1,0 +1,416 @@
+"""Tests for marker's page-locator capture.
+
+marker is the only backend that works on a scanned book, so it is exactly
+the backend a home-scanned print book depends on — and it was declaring
+`page_numbering: "none"`, which would have routed every scan away from a
+citable address permanently.
+
+marker already reads the printed page number; it classifies the running head
+as a PageHeader block and then discards it. `--paginate_output` recovers the
+page boundary and `--keep_pageheader_in_output` /
+`--keep_pagefooter_in_output` recover the furniture that carries the folio,
+which we then strip back out.
+
+Both bands matter. Ordinary pages carry a running head with the folio, but
+chapter openers and full-page tables use a *drop folio* at the foot — which
+is what a statistical appendix consists of. A head-only implementation read
+0 folios across Boyatzis's entire appendix while appearing to work.
+
+A rejected alternative — leaving marker's config alone and reading folios
+from a blind crop of each page's margins — is documented in convert.py. It
+made the body provably untouched but could not tell a page number from a
+table cell, and produced samples too noisy to derive any offset at all.
+"""
+import convert
+from report import ConversionReport
+
+
+def marker_page(index, *lines):
+    return f"{{{index}}}" + "-" * 48 + "\n\n" + "\n\n".join(lines) + "\n\n"
+
+
+# A page must be longer than 2x the band depth or the leading and trailing
+# bands overlap and a test cannot tell which one did the work.
+FULL_PAGE_BODY = [f"Body line {n}." for n in range(1, 9)]
+
+
+# --- _split_marker_pages ---------------------------------------------------
+
+
+def test_split_marker_pages_returns_none_when_unpaginated():
+    """No separators means marker ran without --paginate_output.
+
+    This must be distinguishable from "page 0": a caller that treated it as
+    a page index would emit confident wrong addresses for the whole book.
+    """
+    assert convert._split_marker_pages("Just some body text.\n") is None
+
+
+def test_split_marker_pages_keeps_markers_page_indices():
+    text = marker_page(58, "Body one.") + marker_page(59, "Body two.")
+    assert [i for i, _ in convert._split_marker_pages(text)] == [58, 59]
+
+
+def test_split_marker_pages_preserves_gaps_in_index():
+    """marker numbers by sheet, so a blank page still advances the count."""
+    text = marker_page(10, "A.") + marker_page(12, "B.")
+    assert [i for i, _ in convert._split_marker_pages(text)] == [10, 12]
+
+
+# --- furniture stripping ---------------------------------------------------
+
+
+def test_running_head_and_folio_are_captured_and_removed():
+    pages = convert._split_marker_pages(
+        marker_page(58, "Job Performance as a Criterion Measure", "43", "Body text here.")
+        + marker_page(60, "Job Performance as a Criterion Measure", "45", "More body.")
+        + marker_page(62, "Job Performance as a Criterion Measure", "47", "Yet more."))
+    headers = convert._marker_recurring_lines(pages)
+    folio, body = convert._strip_marker_page_furniture(pages[0][1], headers, set())
+    assert folio == "43"
+    assert body.strip() == "Body text here."
+
+
+def test_running_head_needs_repetition_so_body_prose_survives():
+    """Frequency is the whole safety argument for stripping: a running head
+    appears on many pages, an opening sentence appears once."""
+    pages = convert._split_marker_pages(
+        marker_page(5, "A singular opening sentence.", "Rest of the page.")
+        + marker_page(6, "A different opening.", "Rest again."))
+    headers = convert._marker_recurring_lines(pages)
+    assert headers == set()
+    _folio, body = convert._strip_marker_page_furniture(pages[0][1], headers, set())
+    assert body.startswith("A singular opening sentence.")
+
+
+def test_stripping_stops_at_first_body_line():
+    pages = convert._split_marker_pages(
+        marker_page(1, "Running Head", "Body.", "Running Head")
+        + marker_page(2, "Running Head", "Other.")
+        + marker_page(3, "Running Head", "Third."))
+    headers = convert._marker_recurring_lines(pages)
+    _folio, body = convert._strip_marker_page_furniture(pages[0][1], headers, set())
+    assert "Body." in body
+    assert body.count("Running Head") == 1
+
+
+def test_a_recurring_markdown_heading_is_never_stripped():
+    """Content, not furniture. Boyatzis repeats '## THE COMPETENT MANAGER' on
+    three half-titles; frequency alone would delete it, and marker's own
+    default output keeps it. This was a real 3-line data loss."""
+    text = "".join(marker_page(i, "## THE COMPETENT MANAGER", "Body.") for i in (1, 2, 3, 4))
+    pages = convert._split_marker_pages(text)
+    headers = convert._marker_recurring_lines(pages)
+    assert "## THE COMPETENT MANAGER" in headers          # it does recur...
+    _folio, body = convert._strip_marker_page_furniture(pages[0][1], headers, set())
+    assert "## THE COMPETENT MANAGER" in body             # ...but survives
+
+
+def test_drop_folio_at_the_foot_of_the_page_is_captured():
+    """An appendix table page has no running head: the caption is the first
+    block and the folio sits alone at the bottom. The body is long enough
+    that the folio is outside the leading band, so this fails if the trailing
+    band is not read."""
+    pages = convert._split_marker_pages(
+        marker_page(300, "TABLE A-16 Mean Motive and Trait Levels", *FULL_PAGE_BODY, "285"))
+    folio, body = convert._strip_marker_page_furniture(pages[0][1], set(), set())
+    assert folio == "285"
+    assert "285" not in body
+    assert body.strip().startswith("TABLE A-16")
+
+
+def test_running_head_folio_is_captured_from_the_leading_band():
+    """Mirror of the drop-folio case, so neither band can be dropped."""
+    pages = convert._split_marker_pages(
+        marker_page(58, "Job Performance as a Criterion Measure", "43", *FULL_PAGE_BODY))
+    folio, body = convert._strip_marker_page_furniture(pages[0][1], set(), set())
+    assert folio == "43"
+    assert body.strip().endswith("Body line 8.")
+
+
+def test_footer_folio_does_not_eat_a_trailing_table_row():
+    pages = convert._split_marker_pages(
+        marker_page(300, "| Stage IV | 1.525 | 1.612 |", "285"))
+    _folio, body = convert._strip_marker_page_furniture(pages[0][1], set(), set())
+    assert "| Stage IV | 1.525 | 1.612 |" in body
+
+
+def test_trailing_number_run_is_not_consumed_wholesale():
+    """A page can legitimately end in a run of bare numbers — an index
+    column, or a table whose final rows are unlabelled. Without a bound,
+    stripping would walk up the run and delete real content invisibly."""
+    pages = convert._split_marker_pages(
+        marker_page(300, "Index", *FULL_PAGE_BODY, "101", "102", "103", "104", "105"))
+    _folio, body = convert._strip_marker_page_furniture(pages[0][1], set(), set())
+    remaining = [l for l in body.split("\n") if l.strip()]
+    assert "101" in remaining, "stripping walked past its bound into page content"
+
+
+def test_folio_zero_is_rejected_outright():
+    """No book prints page 0, so a captured '0' is always a misread. This
+    needs no evidence from the rest of the book."""
+    assert convert._is_marker_folio("0") is False
+    assert convert._is_marker_folio("1") is True
+    pages = convert._split_marker_pages(
+        marker_page(24, "0", "The Purpose of this Study", *FULL_PAGE_BODY))
+    folio, _body = convert._strip_marker_page_furniture(pages[0][1], set(), set())
+    assert folio != "0"
+
+
+def test_roman_front_matter_folio_is_captured():
+    pages = convert._split_marker_pages(marker_page(8, "xiv", "Preface text."))
+    folio, body = convert._strip_marker_page_furniture(pages[0][1], set(), set())
+    assert folio == "xiv"
+    assert body.strip() == "Preface text."
+
+
+# --- _rewrite_marker_page_locators ----------------------------------------
+
+
+def _rewrite(tmp_path, text):
+    target = tmp_path / "book.md"
+    target.write_text(text, encoding="utf-8")
+    report = ConversionReport(source="b.pdf", output=str(target), method="marker")
+    convert._rewrite_marker_page_locators(target, report)
+    return target.read_text(encoding="utf-8"), report
+
+
+def test_rewrite_emits_typed_locators(tmp_path):
+    text = (marker_page(58, "Running Head", "43", "First.")
+            + marker_page(59, "Running Head", "44", "Second.")
+            + marker_page(60, "Running Head", "45", "Third."))
+    out, report = _rewrite(tmp_path, text)
+    assert "<!-- page_pdf=58 page_printed=43 -->" in out
+    assert "<!-- page_pdf=60 page_printed=45 -->" in out
+    assert report.page_numbering == "printed"
+    assert report.page_printed_offset == -15
+    assert report.page_printed_offset_consistent is True
+
+
+def test_rewrite_interpolates_between_samples(tmp_path):
+    text = (marker_page(58, "Running Head", "43", "First.")
+            + marker_page(59, "Running Head", "Chapter opener with no folio.")
+            + marker_page(60, "Running Head", "45", "Third.")
+            + marker_page(61, "Running Head", "46", "Fourth."))
+    out, report = _rewrite(tmp_path, text)
+    assert "<!-- page_pdf=59 page_printed=44 -->" in out
+    assert report.page_printed_count == 3          # interpolated pages are not captured
+    assert report.page_locator_count == 4
+
+
+def test_rewrite_refuses_to_extrapolate_past_the_last_sample(tmp_path):
+    """Endnotes often restart numbering. Outside the sampled span there is no
+    evidence the offset still holds, so emit none rather than a guess."""
+    text = (marker_page(10, "Running Head", "5", "A.")
+            + marker_page(11, "Running Head", "6", "B.")
+            + marker_page(12, "Running Head", "7", "C.")
+            + marker_page(40, "Running Head", "Endnotes with no folio."))
+    out, _report = _rewrite(tmp_path, text)
+    assert "<!-- page_pdf=40 page_printed=none -->" in out
+
+
+def test_front_matter_before_the_first_sample_gets_no_page_number(tmp_path):
+    """The span clamp is what prevents interpolating backwards into roman
+    front matter. (`candidate >= 1` in the rewrite is belt-and-braces from
+    the pymupdf path; with a consistent offset and a span clamped to real
+    printed numbers it is unreachable, so no test claims to exercise it.)"""
+    text = (marker_page(20, "Running Head", "1", "Chapter one.")
+            + marker_page(21, "Running Head", "2", "More.")
+            + marker_page(22, "Running Head", "3", "More still.")
+            + marker_page(2, "Running Head", "Front matter."))
+    out, _report = _rewrite(tmp_path, text)
+    assert "<!-- page_pdf=2 page_printed=none -->" in out
+    assert "page_printed=0" not in out
+
+
+def test_misread_folio_is_replaced_by_the_interpolated_value(tmp_path):
+    """End to end: a captured number contradicting the book's offset must not
+    reach the output, and the reader must be told it was overridden."""
+    text = "".join(
+        marker_page(s, "Running Head", "30" if s == 54 else str(s - 15), f"Body {s}.")
+        for s in range(20, 60))
+    out, report = _rewrite(tmp_path, text)
+    assert "<!-- page_pdf=54 page_printed=39 -->" in out
+    assert "<!-- page_pdf=54 page_printed=30 -->" not in out
+    assert any("misread" in w and "page_pdf=54" in w for w in report.warnings)
+    assert report.page_printed_count == 39
+
+
+def test_rewrite_marks_unpaginated_output_as_uncitable(tmp_path):
+    """A caller can override the locator flags via --marker-args. That must
+    degrade to an explicit 'none' plus a warning, not a crash."""
+    out, report = _rewrite(tmp_path, "Body text with no separators.\n")
+    assert out == "Body text with no separators.\n"
+    assert report.page_numbering == "none"
+    assert any("not paginated" in w for w in report.warnings)
+
+
+def test_rewrite_reports_pdf_only_when_no_folio_is_readable(tmp_path):
+    """Deep Work has no printed numbers anywhere. The sheet index is still a
+    real address, so it is pdf_only, not none."""
+    text = marker_page(1, "Body one.") + marker_page(2, "Body two.")
+    out, report = _rewrite(tmp_path, text)
+    assert report.page_numbering == "pdf_only"
+    assert "<!-- page_pdf=1 page_printed=none -->" in out
+
+
+def test_locator_args_request_both_bands():
+    """Regression guard: dropping the footer flag silently halves capture on
+    any book with drop folios."""
+    assert "--paginate_output" in convert.MARKER_LOCATOR_ARGS
+    assert "--keep_pageheader_in_output" in convert.MARKER_LOCATOR_ARGS
+    assert "--keep_pagefooter_in_output" in convert.MARKER_LOCATOR_ARGS
+
+
+def test_marker_is_no_longer_hardcoded_as_uncitable():
+    """Regression guard for the bug this file exists to fix."""
+    assert "marker" not in convert.BACKEND_PAGE_NUMBERING
+    report = ConversionReport(source="b.pdf", output="o.md", method="marker",
+                              page_numbering="printed")
+    convert._apply_backend_page_numbering(report)
+    assert report.page_numbering == "printed"
+
+
+# --- consensus outlier rejection -------------------------------------------
+#
+# Strict unanimity protected interpolated numbers but left CAPTURED ones
+# unguarded, so a single misread digit both blocked interpolation for the
+# rest of the book and was published verbatim as a page number. Boyatzis
+# printed 9 and 39 on two pages that OCR read as "0" and "30".
+#
+# Rejecting an outlier is only safe when the consensus is overwhelming and
+# the dissent is scattered: a book that genuinely renumbers produces a
+# CONTIGUOUS RUN at the new offset, never isolated singletons.
+
+
+def samples(offset, sheets, overrides=None):
+    """Captured-folio dict with a constant offset, plus explicit overrides."""
+    out = {s: str(s + offset) for s in sheets}
+    out.update({k: str(v) for k, v in (overrides or {}).items()})
+    return out
+
+
+def test_isolated_outlier_is_rejected_when_consensus_is_overwhelming():
+    s = samples(-15, range(20, 60), {54: 30})   # 54 should print 39
+    offset, consistent = convert._derive_page_offset(s)
+    assert (offset, consistent) == (-15, True)
+    assert convert._page_offset_outliers(s, offset) == {54}
+
+
+def test_contiguous_dissent_is_a_renumbering_and_still_refuses():
+    """The guard that keeps this from flattening a real second sequence.
+
+    Enough samples to clear the agreement threshold, so this proves the RUN
+    rule rather than the threshold.
+    """
+    s = samples(-15, range(20, 70))
+    for sheet in range(60, 70):            # endnotes restarting at 1
+        s[sheet] = str(sheet - 59)
+    assert convert._derive_page_offset(s) == (None, False)
+
+
+def test_two_adjacent_dissenters_are_enough_to_refuse():
+    """Adjacency is the signal, not volume — a restart begins somewhere."""
+    s = samples(-15, range(20, 60), {54: 30, 55: 31})
+    assert convert._derive_page_offset(s) == (None, False)
+
+
+def test_weak_agreement_refuses():
+    """Dissenters spaced far enough apart to clear the run guard, so this
+    isolates the agreement threshold rather than passing on adjacency.
+
+    Widespread disagreement means the offset model itself is wrong for this
+    book — not that a few digits were misread.
+    """
+    s = samples(-15, range(20, 60))
+    dissenters = list(range(20, 60, 6))    # 7 of 40, none adjacent
+    for sheet in dissenters:
+        s[sheet] = str(sheet - 15 + 3)
+    assert max(b - a for a, b in zip(dissenters, dissenters[1:])) > 2
+    assert convert._derive_page_offset(s) == (None, False)
+
+
+def test_small_non_unanimous_sample_sets_cannot_reach_consensus():
+    """Below 20 samples any dissent drops agreement under the threshold, so
+    the original strict rule still governs small books. Documented as a
+    property rather than a separate guard, because a minimum-samples check
+    would be unreachable."""
+    for n in (5, 10, 19):
+        s = samples(-15, range(20, 20 + n), {21: 999})
+        assert convert._derive_page_offset(s) == (None, False), n
+
+
+def test_unanimous_samples_are_unaffected():
+    s = samples(-15, range(20, 60))
+    assert convert._derive_page_offset(s) == (-15, True)
+    assert convert._page_offset_outliers(s, -15) == set()
+
+
+def test_outliers_are_empty_when_no_offset_was_derived():
+    s = samples(-15, range(20, 60), {54: 30, 55: 31})
+    assert convert._page_offset_outliers(s, None) == set()
+
+
+# --- flag plumbing ---------------------------------------------------------
+
+
+def _fake_marker(seen, body):
+    """Stand in for marker_single: record the command, write a paginated file."""
+    from pathlib import Path
+
+    class FakeProc:
+        def __init__(self, cmd, **_kw):
+            seen["cmd"] = cmd
+            out = Path(cmd[cmd.index("--output_dir") + 1]) / "book"
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "book.md").write_text(body, encoding="utf-8")
+            self.stdout = iter(())
+
+        def wait(self):
+            return 0
+
+    return FakeProc
+
+
+def test_locator_flags_actually_reach_marker(tmp_path, monkeypatch):
+    """The constant being correct does not prove it is passed. Without the
+    flags marker emits no separators, and every scanned book silently loses
+    its page addresses again — the exact regression this work undoes.
+    """
+    seen = {}
+    body = (marker_page(10, "Running Head", "1", "Body one.")
+            + marker_page(11, "Running Head", "2", "Body two.")
+            + marker_page(12, "Running Head", "3", "Body three."))
+    monkeypatch.setattr(convert.subprocess, "Popen", _fake_marker(seen, body))
+    monkeypatch.setattr(convert, "apply_table_signals", lambda *a, **k: None)
+    pdf = tmp_path / "book.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()                      # convert_book normally creates this
+
+    report = convert.convert_with_marker(pdf, out_dir)
+
+    for flag in convert.MARKER_LOCATOR_ARGS:
+        assert flag in seen["cmd"], f"{flag} never reached marker_single"
+    assert report.page_numbering == "printed"
+
+
+def test_user_marker_args_are_appended_not_substituted(tmp_path, monkeypatch):
+    """`--marker-args` must not displace the locator flags: table quality and
+    page addressing are independent concerns."""
+    seen = {}
+    body = (marker_page(10, "Running Head", "1", "Body one.")
+            + marker_page(11, "Running Head", "2", "Body two.")
+            + marker_page(12, "Running Head", "3", "Body three."))
+    monkeypatch.setattr(convert.subprocess, "Popen", _fake_marker(seen, body))
+    monkeypatch.setattr(convert, "apply_table_signals", lambda *a, **k: None)
+    pdf = tmp_path / "book.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    convert.convert_with_marker(pdf, out_dir, marker_args=["--use_llm"])
+
+    assert "--use_llm" in seen["cmd"]
+    for flag in convert.MARKER_LOCATOR_ARGS:
+        assert flag in seen["cmd"]


### PR DESCRIPTION
## The problem

PR #22 gave every backend a typed page address — except it recorded `"marker": "none"` as a fixed capability. marker is the **only** backend that works on a scanned book: `pymupdf` needs a text layer the scan doesn't have, and `ocr` has no table handling.

So the one backend a home-scanned print book depends on was also the one guaranteed to file it without page numbers — and #22's ingestion gate, whose job is to "route away from a backend that can't produce a citable address," would have made that permanent. Every book scanned on the new Brother, uncitable by page, by design.

marker was already reading the printed page number. It classifies the running head as a `PageHeader` block and then discards it.

## What this does

Requests three renderer flags — `--paginate_output` for a `{N}-----` separator per page, and `--keep_pageheader_in_output` / `--keep_pagefooter_in_output` so the furniture carrying the folio survives — captures the number, and strips the furniture back out. marker now decides `printed` vs `pdf_only` at runtime, like `pymupdf`.

**Both bands are required.** Ordinary pages carry a running head with the folio, but chapter openers and full-page tables use a *drop folio* at the foot — which is what a statistical appendix consists of. A head-only version read **0 folios across Boyatzis's entire appendix while appearing to work.**

Offset derivation, span clamping and interpolation are reused from #22 unchanged, so both backends fail closed identically.

## Consensus outlier rejection

Strict unanimity protected *interpolated* numbers but left *captured* ones unguarded. Boyatzis prints 9 and 39 on two pages that OCR read as `0` and `30`. Those two misreads blocked interpolation for 42 other pages **and were published verbatim as page numbers** — the exact harm this work exists to prevent.

A dominant offset is now accepted when agreement is ≥95% **and the dissenters are not adjacent**, and contradicting captures are suppressed with a warning so interpolation supplies the right number.

The adjacency rule is the safety property: a book that genuinely renumbers (endnotes restarting at 1) produces a **contiguous run** at the new offset, never isolated singletons. Arabic `0` is rejected outright — no book prints page 0.

Two guards were **removed** rather than left implying protection they never gave: a minimum-samples check (with any dissent, 95% agreement already requires ≥20 samples, so it was unreachable) and an explicit unanimity branch (subsumed by the consensus path). Mutation testing is what exposed both.

## Verification

Boyatzis's *The Competent Manager*, a 330-page home scan:

| | |
|---|---|
| offset | **−15, consistent** |
| locators emitted | 330 |
| carrying a printed page number | **313** |
| `none` | 17 (all outside the sampled span) |

Five sheets checked by hand against the page images — **24→9, 54→39, 58→43, 60→45, 300→285**, all correct. Whole-book differential against a default-config conversion: **0 content deleted**.

That differential first showed **3 real deletions** — a recurring part-title (`## THE COMPETENT MANAGER`) eaten by the frequency rule. marker renders furniture as plain text and never as a heading, so headings are now never stripped.

## Known tradeoff

**108 furniture lines (~0.3/page) remain inline**, because this book's running head is the *section* title and recurs only twice — below the repeat threshold. Lossless but noisier than marker's default, so this does **not** meet the "0 cleaned-text differences" bar #22 hit for pymupdf.

Two attempts to close it — lowering the threshold, and letting a folio vouch for adjacent short lines — both started deleting real content (a figure's image reference, a caption) and were rejected. Residue is strictly better than loss.

## A measured dead end

A larger alternative was implemented and run over the whole book: leave marker's config untouched and read folios from an independent OCR crop of each page's margins. It makes the body *provably* unchanged, which is why it was worth trying.

It doesn't work. A blind crop cannot tell a page number from a table cell:

| | marker's own reading | margin crop |
|---|---|---|
| folios captured | 288/330 | 237/330 |
| offset agreement | 99.3% | 85.7% |
| offset derived | −15 ✓ | **none** |

The failures cluster on the appendix — full-page statistical tables — reading cell values (`709`, `917`, `973`) and concatenating digits (`197` → `1907`). Below the consensus threshold the book gets **no** interpolation and ~33 wrong captured numbers. Tightening the band to 5% made it far worse (5/23 captured); this scan's margins are generous, so the folio sits deeper.

The rationale is recorded in `convert.py` so it isn't retried blind.

## Tests

31 new cases: separator parsing, both folio bands, the heading guard, strip bounds, consensus acceptance and refusal, misread suppression, and the flag plumbing actually reaching `marker_single`. **156 → 187 passing.**

**Twelve mutations verified caught.** Three earlier rounds of tests passed against deliberately broken code — guards masked by the span clamp, and synthetic pages so short the two folio bands overlapped — and were rewritten to isolate what they claim.

Also widens `.gitignore`: `output/**/*.md` alone let a `git add -A` sweep in sidecar reports, extracted images, run logs and archived source books.

## Paired change

mc-wiki `runbooks/source-ingestion.md` v0.7.0 reverses its Step 2 routing table, which currently tells the reader marker "produces no page locators" and steers them to `pymupdf` for anything citable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)