### PR TITLE
feat(convert): warn before a long conversion when memory is short

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -2988,6 +2988,115 @@ def _rewrite_marker_page_locators(target, report):
           + (f", offset {offset:+d}" if offset_consistent else ", offset inconsistent"))
 
 
+# --- memory pre-flight ------------------------------------------------------
+#
+# marker holds its model weights resident — ~8.6 GB on a book-length scan. On a
+# machine with no free RAM those weights get paged in and out continuously, and
+# the run does not fail, it crawls: Ross & Nisbett ran ~50x slower per text unit
+# than Boyatzis on the same laptop (0.14 vs 7 units/sec) purely because free
+# memory had fallen to ~94 MB with 19M swapouts. A 1-hour conversion became a
+# 13-hour one.
+#
+# That is worth a warning and not a block. The estimate is what the operator
+# actually needs — "close something" is only actionable next to "or wait 13
+# hours" — and a wrong guess about headroom must never stop a conversion the
+# user asked for.
+
+MARKER_RESIDENT_GB = 8.6      # measured peak RSS on a 330-page scan
+
+
+def _pdf_page_count(pdf_path):
+    """Page count for the warning message, or None if the PDF won't open.
+
+    Best-effort by design: this exists to make a warning specific, and must
+    never be the reason a conversion does not start.
+    """
+    try:
+        import fitz
+        with fitz.open(str(pdf_path)) as doc:
+            return len(doc)
+    except Exception:      # noqa: BLE001 - cosmetic detail, never fatal
+        return None
+
+
+def _free_memory_gb():
+    """Free + compressible memory in GB, or None if it cannot be determined.
+
+    Parses `vm_stat` (macOS). Returns None anywhere else rather than guessing,
+    so the caller degrades to saying nothing.
+    """
+    if sys.platform != "darwin":
+        return None
+    try:
+        out = subprocess.run(["vm_stat"], capture_output=True, text=True, timeout=5)
+        if out.returncode != 0:
+            return None
+        stats, page_size = {}, 4096
+        for line in out.stdout.splitlines():
+            m = re.match(r"Mach Virtual Memory Statistics: \(page size of (\d+) bytes\)", line)
+            if m:
+                page_size = int(m.group(1))
+                continue
+            m = re.match(r"^(.*?):\s+(\d+)\.?$", line)
+            if m:
+                stats[m.group(1).strip()] = int(m.group(2))
+        free_pages = stats.get("Pages free", 0) + stats.get("Pages inactive", 0)
+        return free_pages * page_size / (1024 ** 3)
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+
+
+def _swap_used_gb():
+    """Swap currently in use, in GB, or None if it cannot be determined."""
+    if sys.platform != "darwin":
+        return None
+    try:
+        out = subprocess.run(["sysctl", "-n", "vm.swapusage"],
+                             capture_output=True, text=True, timeout=5)
+        m = re.search(r"used\s*=\s*([\d.]+)([MG])", out.stdout)
+        if not m:
+            return None
+        value = float(m.group(1))
+        return value / 1024 if m.group(2) == "M" else value
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+
+
+# Swap is context, not a trigger. macOS leaves pages swapped out long after the
+# pressure that caused them is gone — this machine still showed 1.2 GB of swap
+# in use with 33 GB free, right after the thrashing conversion was killed — so
+# swapping alone says nothing about whether the next run has room. Free memory
+# is the decision variable; swap only sharpens the diagnosis when memory is
+# already short.
+SWAP_PRESSURE_GB = 1.0
+
+
+def warn_if_memory_is_tight(page_count=None):
+    """Warn before a long conversion when the machine has no room for it.
+
+    Returns the free-GB figure (or None) so callers can record it.
+    """
+    free_gb = _free_memory_gb()
+    swap_gb = _swap_used_gb()
+    if free_gb is None or free_gb >= MARKER_RESIDENT_GB:
+        return free_gb
+    swapping = swap_gb is not None and swap_gb >= SWAP_PRESSURE_GB
+    pages = f"{page_count}-page " if page_count else ""
+    swap_note = (f" {swap_gb:.1f} GB of swap is already in use."
+                 if swapping else "")
+    print(
+        f"  WARNING: only {free_gb:.1f} GB of memory is free, and marker needs "
+        f"about {MARKER_RESIDENT_GB:.0f} GB resident.{swap_note}\n"
+        f"  This {pages}conversion will still finish, but the model weights will "
+        f"page in and out of swap the whole way and it can run an order of "
+        f"magnitude slower — hours instead of about one.\n"
+        f"  Close what you can (browsers and Electron apps are usually the "
+        f"biggest holders) and re-run, or leave it going in the background.",
+        file=sys.stderr,
+    )
+    return free_gb
+
+
 def convert_with_marker(pdf_path, output_dir, marker_args=None):
     """Convert a text-based PDF using Marker.
 
@@ -2998,6 +3107,7 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None):
     Raises ConversionError on failure.
     """
     print(f"Converting with Marker: {pdf_path.name}")
+    warn_if_memory_is_tight(_pdf_page_count(pdf_path))
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Newer marker-pdf releases (≥1.0) take the output path via the

--- a/tests/test_memory_preflight.py
+++ b/tests/test_memory_preflight.py
@@ -1,0 +1,120 @@
+"""Tests for the pre-conversion memory warning.
+
+marker holds ~8.6 GB of model weights resident. On a machine with no free RAM
+the run does not fail, it crawls: Ross & Nisbett ran ~50x slower per text unit
+than Boyatzis on the same laptop (0.14 vs 7 units/sec) purely because free
+memory had fallen to ~94 MB. A one-hour conversion became a thirteen-hour one,
+and nothing in the output said why.
+
+The warning must never block a conversion — a wrong guess about headroom
+stopping work the user asked for is worse than a slow run.
+"""
+import subprocess
+
+import pytest
+
+import convert
+
+
+VM_STAT_HEALTHY = """Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages free:                             1157727.
+Pages active:                           2000000.
+Pages inactive:                         3000000.
+Pages speculative:                        50000.
+"""
+
+VM_STAT_STARVED = """Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages free:                               24136.
+Pages active:                           8000000.
+Pages inactive:                           30000.
+Pages speculative:                          500.
+"""
+
+
+def fake_run(stdout, returncode=0):
+    def _run(*_a, **_k):
+        return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr="")
+    return _run
+
+
+def test_free_memory_parses_vm_stat(monkeypatch):
+    monkeypatch.setattr(convert.subprocess, "run", fake_run(VM_STAT_HEALTHY))
+    monkeypatch.setattr(convert.sys, "platform", "darwin")
+    # free + inactive = 4,157,727 pages * 4096 bytes
+    assert convert._free_memory_gb() == pytest.approx(4157727 * 4096 / 1024**3)
+
+
+def test_no_warning_when_memory_is_ample(monkeypatch, capsys):
+    monkeypatch.setattr(convert, "_free_memory_gb", lambda: 33.5)
+    monkeypatch.setattr(convert, "_swap_used_gb", lambda: 0.0)
+    convert.warn_if_memory_is_tight(304)
+    assert capsys.readouterr().err == ""
+
+
+def test_residual_swap_alone_does_not_warn(monkeypatch, capsys):
+    """macOS leaves pages swapped long after the pressure is gone — this
+    machine showed 1.2 GB swapped with 33 GB free right after the thrashing
+    run was killed. Warning on that would cry wolf on a healthy machine."""
+    monkeypatch.setattr(convert, "_free_memory_gb", lambda: 33.5)
+    monkeypatch.setattr(convert, "_swap_used_gb", lambda: 1.2)
+    convert.warn_if_memory_is_tight(304)
+    assert capsys.readouterr().err == ""
+
+
+def test_warns_when_free_memory_is_below_what_marker_needs(monkeypatch, capsys):
+    monkeypatch.setattr(convert, "_free_memory_gb", lambda: 0.1)
+    monkeypatch.setattr(convert, "_swap_used_gb", lambda: 0.0)
+    convert.warn_if_memory_is_tight(304)
+    err = capsys.readouterr().err
+    assert "0.1 GB" in err
+    assert "304-page" in err
+    assert "slower" in err          # the estimate is the actionable part
+
+
+def test_swap_sharpens_the_diagnosis_when_memory_is_short(monkeypatch, capsys):
+    """When memory IS short, active swapping is worth naming — it tells the
+    operator the slowdown has already started rather than being a forecast."""
+    monkeypatch.setattr(convert, "_free_memory_gb", lambda: 0.1)
+    monkeypatch.setattr(convert, "_swap_used_gb", lambda: 19.0)
+    convert.warn_if_memory_is_tight(304)
+    assert "19.0 GB of swap" in capsys.readouterr().err
+
+
+def test_undeterminable_memory_says_nothing(monkeypatch, capsys):
+    """On a platform we cannot read, stay silent rather than guess."""
+    monkeypatch.setattr(convert, "_free_memory_gb", lambda: None)
+    monkeypatch.setattr(convert, "_swap_used_gb", lambda: None)
+    assert convert.warn_if_memory_is_tight(304) is None
+    assert capsys.readouterr().err == ""
+
+
+def test_free_memory_returns_none_off_darwin(monkeypatch):
+    monkeypatch.setattr(convert.sys, "platform", "linux")
+    assert convert._free_memory_gb() is None
+    assert convert._swap_used_gb() is None
+
+
+def test_vm_stat_failure_is_not_fatal(monkeypatch):
+    monkeypatch.setattr(convert.sys, "platform", "darwin")
+    monkeypatch.setattr(convert.subprocess, "run", fake_run("", returncode=1))
+    assert convert._free_memory_gb() is None
+
+
+def test_page_count_failure_is_not_fatal(tmp_path):
+    """The page count only makes the message specific; an unreadable PDF must
+    not stop the conversion before it starts."""
+    bad = tmp_path / "not-a.pdf"
+    bad.write_bytes(b"nonsense")
+    assert convert._pdf_page_count(bad) is None
+
+
+def test_swap_is_not_mentioned_when_there_is_none(monkeypatch, capsys):
+    """Short on memory but not swapping is a forecast, not a diagnosis.
+    Claiming swap is 'already in use' when it isn't would misdescribe the
+    machine and send the operator hunting for a problem they don't have."""
+    monkeypatch.setattr(convert, "_free_memory_gb", lambda: 0.1)
+    monkeypatch.setattr(convert, "_swap_used_gb", lambda: 0.0)
+    convert.warn_if_memory_is_tight(304)
+    # "swap" appears in the general explanation of WHY it will be slow; what
+    # must be absent is the claim that swapping has already started.
+    assert "already in use" not in capsys.readouterr().err


### PR DESCRIPTION
## The problem

marker holds ~8.6 GB of model weights resident. On a machine with no free RAM the run doesn't fail — it crawls, and nothing in the output says why.

Two book-length scans on the same laptop:

| | pages | text units | time | rate |
|---|---|---|---|---|
| Boyatzis | 330 | 4,567 | **10:50** | ~7/sec |
| Ross & Nisbett | 304 | 229 of 6,831 | **27:39** | **~0.14/sec** |

**~50× slower per unit**, on a job only 1.5× bigger. The difference was free memory: it had fallen to ~94 MB with 19M swapouts while marker tried to hold 8.6 GB. A one-hour conversion had become a thirteen-hour one, and the only clue was a progress bar quietly revising its ETA upward.

## What this does

`convert_with_marker` reports free memory before starting and, when there's less than marker needs, says what that will cost:

```
WARNING: only 0.1 GB of memory is free, and marker needs about 9 GB resident.
19.0 GB of swap is already in use.
This 304-page conversion will still finish, but the model weights will page in
and out of swap the whole way and it can run an order of magnitude slower —
hours instead of about one.
Close what you can (browsers and Electron apps are usually the biggest holders)
and re-run, or leave it going in the background.
```

**It warns and never blocks.** A wrong guess about headroom must not stop a conversion the user asked for. The estimate is the part that makes "close something" actionable — without it the operator has no way to weigh closing their apps against waiting.

## Swap is context, not a trigger

My first version warned on free memory **or** swap in use. That fires on a healthy machine: macOS leaves pages swapped long after the pressure is gone, and this laptop showed 1.2 GB swapped with **33 GB free** immediately after the thrashing run was killed — producing the absurd "only 33.6 GB is free" warning.

So free memory decides, and swap is named only when memory is already short — where it usefully distinguishes "this will get slow" from "this is already slow."

## Degradation

Reads `vm_stat` and `sysctl vm.swapusage`. Returns `None` off darwin, on non-zero exit, or on any parse failure, and the caller then says nothing rather than guessing. The page count in the message is best-effort for the same reason — an unreadable PDF must not stop a conversion before it starts.

## Tests

10 cases: the `vm_stat` parse, the threshold, the residual-swap false positive, absence of the swap claim on a non-swapping machine, and every degradation path.

Five mutations verified caught — including one that **survived** until I added a test asserting the swap note is *absent* when there is no swapping. `216 passed, 8 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)