### PR TITLE
feat(convert): tell the operator when another conversion is already running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ output/**/*.jpeg
 output/**/*.json
 archive/
 logs/
+
+# Per-machine registry of running conversions (advisory concurrency notice)
+.active-conversions.json

--- a/convert.py
+++ b/convert.py
@@ -24,6 +24,7 @@ Usage:
 import argparse
 import collections
 import io
+import json
 import logging
 import os
 import shlex
@@ -32,6 +33,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import traceback
 from pathlib import Path
 
@@ -3631,6 +3633,97 @@ def _apply_cleanup(result):
     return result
 
 
+# --- concurrent conversions -------------------------------------------------
+#
+# One BookConvert checkout is shared by several agent sessions and by Andy.
+# The realistic collision is not two people converting the same book: it is one
+# workspace running a two-hour OCR of a scanned book while another converts a
+# handful of papers for an unrelated project. Both should proceed — serialising
+# them would make the small job wait hours for no reason — but neither should
+# be surprised by the other.
+#
+# Surprise is the actual cost. A concurrent run halves the CPU each gets and
+# doubles resident memory, which turns an unexplained slowdown into a
+# diagnosis that took an hour of process archaeology to reach: two markers,
+# ~7 GB each, on a machine whose free memory had already gone.
+#
+# So this registry is advisory and never blocks. It answers one question at
+# the moment it matters — "is anything else running, and for how long?" — and
+# composes with the memory warning above, because "4 GB free" means something
+# different when another conversion already holds 8 of them.
+
+ACTIVE_CONVERSIONS = Path(__file__).resolve().parent / ".active-conversions.json"
+
+
+def _process_alive(pid):
+    """Whether `pid` is still running. Stale entries are the normal case:
+    a killed or crashed conversion never gets to clean up after itself."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True          # exists, owned by someone else
+    return True
+
+
+def read_active_conversions(exclude_pid=None):
+    """Live entries from the registry, pruning any whose process has gone."""
+    try:
+        raw = json.loads(ACTIVE_CONVERSIONS.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    if not isinstance(raw, list):
+        return []
+    return [e for e in raw
+            if isinstance(e, dict)
+            and isinstance(e.get("pid"), int)
+            and e["pid"] != exclude_pid
+            and _process_alive(e["pid"])]
+
+
+def _write_active_conversions(entries):
+    try:
+        ACTIVE_CONVERSIONS.write_text(json.dumps(entries, indent=1) + "\n",
+                                      encoding="utf-8")
+    except OSError:
+        pass                 # advisory only; never fail a conversion over it
+
+
+def register_conversion(pdf_path, method, started_at):
+    """Record this run, and return what was already running.
+
+    Returns the list of other live conversions so the caller can report them.
+    """
+    others = read_active_conversions(exclude_pid=os.getpid())
+    entry = {"pid": os.getpid(), "book": Path(pdf_path).name,
+             "method": method, "started": started_at}
+    _write_active_conversions(others + [entry])
+    return others
+
+
+def unregister_conversion():
+    _write_active_conversions(read_active_conversions(exclude_pid=os.getpid()))
+
+
+def describe_other_conversions(others, now):
+    """One line per concurrent run, or None when there are none."""
+    if not others:
+        return None
+    lines = ["  NOTE: another conversion is already running on this checkout:"]
+    for e in others:
+        try:
+            mins = max(0, int((now - float(e.get("started", now))) // 60))
+            age = f"{mins // 60}h{mins % 60:02d}m" if mins >= 60 else f"{mins}m"
+        except (TypeError, ValueError):
+            age = "unknown"
+        lines.append(f"    - {e.get('book', '?')} ({e.get('method', '?')}), "
+                     f"running {age}, pid {e.get('pid')}")
+    lines.append("  Both will finish. Expect each to be slower, and expect "
+                 "roughly 8 GB more memory in use than you would otherwise.")
+    return "\n".join(lines)
+
+
 def convert_book(book_path, output_dir, method="pymupdf", auto_ocr=False,
                  extract_images=False, clean=True, marker_args=None):
     """Convert a single book (PDF or EPUB) to markdown.
@@ -3938,33 +4031,44 @@ def main():
             print(e)
             sys.exit(1)
 
+    # Tell the operator what else is running before anything slow starts.
+    # `try/finally` around the loop so a crash or Ctrl-C still de-registers;
+    # a stale entry would misreport the next run.
+    others = register_conversion(books[0] if books else "?", method, time.time())
+    notice = describe_other_conversions(others, time.time())
+    if notice:
+        print(notice, file=sys.stderr)
+
     success = 0
     failed = 0
     skipped = 0
     converted_books = []  # successfully converted source paths, for --archive
 
-    for book in books:
-        if args.skip_existing:
-            existing = output_dir / f"{book.stem}.md"
-            if existing.exists():
-                print(f"Skipping (already exists): {book.name}")
-                skipped += 1
-                continue
+    try:
+        for book in books:
+            if args.skip_existing:
+                existing = output_dir / f"{book.stem}.md"
+                if existing.exists():
+                    print(f"Skipping (already exists): {book.name}")
+                    skipped += 1
+                    continue
 
-        if convert_book(
-            book,
-            output_dir,
-            method=method,
-            auto_ocr=args.auto_ocr,
-            extract_images=args.extract_images,
-            clean=not args.no_clean,
-            marker_args=marker_args,
-        ):
-            success += 1
-            converted_books.append(book)
-        else:
-            failed += 1
-        print()
+            if convert_book(
+                book,
+                output_dir,
+                method=method,
+                auto_ocr=args.auto_ocr,
+                extract_images=args.extract_images,
+                clean=not args.no_clean,
+                marker_args=marker_args,
+            ):
+                success += 1
+                converted_books.append(book)
+            else:
+                failed += 1
+            print()
+    finally:
+        unregister_conversion()
 
     parts = [f"{success} converted", f"{failed} failed"]
     if skipped:

--- a/tests/test_concurrent_conversions.py
+++ b/tests/test_concurrent_conversions.py
@@ -1,0 +1,106 @@
+"""Tests for the concurrent-conversion registry.
+
+One BookConvert checkout is shared by several agent sessions. The realistic
+collision is one workspace running a two-hour OCR of a scanned book while
+another converts a few papers for an unrelated project — both should proceed,
+neither should be surprised.
+
+Surprise is the cost being paid. A concurrent run halves each side's CPU and
+doubles resident memory; on 2026-07-27 that turned an unexplained slowdown
+into an hour of process archaeology before anyone noticed two markers were
+running. The registry answers "is anything else running, and for how long?"
+at the moment it matters, and never blocks.
+"""
+import json
+import os
+import time
+
+import convert
+
+
+def use_temp_registry(tmp_path, monkeypatch):
+    reg = tmp_path / ".active-conversions.json"
+    monkeypatch.setattr(convert, "ACTIVE_CONVERSIONS", reg)
+    return reg
+
+
+def test_registers_and_deregisters(tmp_path, monkeypatch):
+    reg = use_temp_registry(tmp_path, monkeypatch)
+    convert.register_conversion("Book.pdf", "marker", time.time())
+    assert [e["book"] for e in json.loads(reg.read_text())] == ["Book.pdf"]
+    convert.unregister_conversion()
+    assert json.loads(reg.read_text()) == []
+
+
+def test_register_returns_what_was_already_running(tmp_path, monkeypatch):
+    reg = use_temp_registry(tmp_path, monkeypatch)
+    reg.write_text(json.dumps([{"pid": os.getpid(), "book": "Boyatzis.pdf",
+                                "method": "marker", "started": time.time()}]))
+    # A different pid registering sees the existing one. The real pid is
+    # captured first: a lambda calling os.getpid() would call the patched
+    # version and recurse forever.
+    other_pid = os.getpid() + 100000
+    monkeypatch.setattr(convert.os, "getpid", lambda: other_pid)
+    others = convert.register_conversion("Paper.pdf", "marker", time.time())
+    assert [e["book"] for e in others] == ["Boyatzis.pdf"]
+
+
+def test_dead_processes_are_pruned(tmp_path, monkeypatch):
+    """A killed or crashed conversion never cleans up after itself, so stale
+    entries are the normal case rather than the exception. Reporting one as
+    live would misdescribe the machine."""
+    reg = use_temp_registry(tmp_path, monkeypatch)
+    reg.write_text(json.dumps([
+        {"pid": os.getpid(), "book": "Live.pdf", "method": "marker", "started": time.time()},
+        {"pid": 999999999, "book": "Dead.pdf", "method": "marker", "started": time.time()},
+    ]))
+    assert [e["book"] for e in convert.read_active_conversions()] == ["Live.pdf"]
+
+
+def test_a_corrupt_registry_is_ignored_not_fatal(tmp_path, monkeypatch):
+    """Advisory only. A malformed file must never stop a conversion."""
+    reg = use_temp_registry(tmp_path, monkeypatch)
+    reg.write_text("{ not json")
+    assert convert.read_active_conversions() == []
+    convert.register_conversion("Book.pdf", "marker", time.time())
+    assert [e["book"] for e in json.loads(reg.read_text())] == ["Book.pdf"]
+
+
+def test_missing_registry_is_ignored(tmp_path, monkeypatch):
+    use_temp_registry(tmp_path, monkeypatch)
+    assert convert.read_active_conversions() == []
+
+
+def test_unwritable_registry_does_not_fail_the_conversion(tmp_path, monkeypatch):
+    monkeypatch.setattr(convert, "ACTIVE_CONVERSIONS",
+                        tmp_path / "nonexistent-dir" / "reg.json")
+    assert convert.register_conversion("Book.pdf", "marker", time.time()) == []
+    convert.unregister_conversion()          # must not raise
+
+
+def test_notice_names_the_book_and_how_long_it_has_run():
+    now = time.time()
+    others = [{"pid": 123, "book": "The Competent Manager.pdf",
+               "method": "marker", "started": now - 95 * 60}]
+    msg = convert.describe_other_conversions(others, now)
+    assert "The Competent Manager.pdf" in msg
+    assert "1h35m" in msg                     # duration is the actionable part
+    assert "8 GB" in msg                      # so is the memory consequence
+
+
+def test_notice_uses_minutes_under_an_hour():
+    now = time.time()
+    msg = convert.describe_other_conversions(
+        [{"pid": 1, "book": "Paper.pdf", "method": "marker", "started": now - 300}], now)
+    assert "5m" in msg
+
+
+def test_no_notice_when_nothing_else_is_running():
+    assert convert.describe_other_conversions([], time.time()) is None
+
+
+def test_a_malformed_timestamp_does_not_break_the_notice():
+    msg = convert.describe_other_conversions(
+        [{"pid": 1, "book": "X.pdf", "method": "marker", "started": "nonsense"}],
+        time.time())
+    assert "unknown" in msg and "X.pdf" in msg


### PR DESCRIPTION
## The case this is for

One BookConvert checkout is shared by several agent sessions and by Andy. The realistic collision isn't two people converting the same book — it's **one workspace running a two-hour OCR of a scanned book while another converts a few papers for an unrelated project.**

Both should proceed. Serialising them would make the small job wait hours for nothing. But neither should be *surprised* by the other.

## Surprise is the cost being paid

A concurrent run halves each side's CPU and doubles resident memory. On 2026-07-27 that produced an unexplained slowdown that took **an hour of process archaeology** to trace to two markers running at once, ~7 GB each, on a machine whose free memory had already gone. Nothing in the output said so — I diagnosed it by reading `ps` output and comparing progress-bar rates between two books.

## What this does

Records each run in `.active-conversions.json` and, before anything slow starts, reports what else is live:

```
NOTE: another conversion is already running on this checkout:
  - The Competent Manager.pdf (marker), running 1h35m, pid 18535
Both will finish. Expect each to be slower, and expect roughly 8 GB more
memory in use than you would otherwise.
```

**Advisory throughout — it never blocks.** And it composes with the memory warning from #24/#25: "4 GB free" means something quite different when another conversion already holds 8 of them.

## Failure modes

Entries are pruned **by liveness rather than trusted** — a killed or crashed conversion never cleans up after itself, so stale entries are the normal case, and reporting one as live would misdescribe the machine.

A corrupt, missing, or unwritable registry is ignored. A coordination hint must never be the reason a conversion fails. De-registration sits in a `finally`, so Ctrl-C or a crash still clears the entry.

## Tests

10 cases: registration, liveness pruning, the duration formatting operators actually read (`1h35m` vs `5m`), and every degradation path. **Six mutations verified caught** — run with `PYTHONDONTWRITEBYTECODE=1` and an explicit `touch` between swaps, per the stale-bytecode lesson from #25.

One mutation initially appeared to survive because my pattern matched the wrong `return []` of five in the file; targeting the exact block showed it caught. Worth noting that a mutation "surviving" is itself a claim that needs checking.

`230 passed, 8 skipped`.

## Not covered here

Two other shared-checkout hazards, both better handled by convention than code, and going into the runbook rather than this PR:

- **Directory mode** (`convert.py input/`) on a shared checkout will pick up the other session's in-progress file. Convert from the source path with an explicit `--output` instead; `input/` is convention, not a requirement.
- **Branch switching** during a run. The running process is immune — Python has already loaded the module — but the *next* conversion silently picks up whatever is checked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)