### PR TITLE
Folio consensus: tolerate scattered dissent, always say why

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,25 @@ assuming it from the `--method` you asked for.
 
 Where printed-page-number survival is sparse, `page_printed_offset` is
 derived from the captured samples and used to fill the gaps — but only
-when at least 3 arabic samples all agree
+when at least 3 arabic samples reach a consensus
 (`page_printed_offset_consistent: true`), and only for PDF pages that fall
 between the first and last captured sample. A book that renumbers partway
 through, or that has printed page numbers only in part of the text, gets no
 interpolation (or interpolation clamped to that span) rather than invented
 page numbers — and interpolation never produces a printed page number
 below 1.
+
+Consensus is not unanimity. At least 85% of the arabic samples must agree
+on one offset, and the samples that disagree must be scattered — two
+dissenters within 2 sheets of each other are read as a renumbering or a
+page-order defect and refuse the whole book. Below 8 samples, unanimity is
+still required, because at that size a misread digit and a genuine second
+numbering sequence are indistinguishable. A folio that contradicts an
+adopted consensus is treated as an OCR misread: it is suppressed, replaced
+by the interpolated value, and reported in `warnings` rather than published
+as a page number a reader would trust. Every refusal is likewise reported
+in `warnings` with its reason, so low coverage always comes with an
+account of itself.
 
 Check coverage after any conversion:
 

--- a/convert.py
+++ b/convert.py
@@ -932,6 +932,15 @@ def _arabic_page_pdf_indices(page_printed_by_pdf_index):
     ]
 
 
+def _page_offset_samples(page_printed_by_pdf_index):
+    """dict of PDF page index -> implied offset, arabic samples only."""
+    return {
+        page_pdf: int(page_printed) - page_pdf
+        for page_pdf, page_printed in page_printed_by_pdf_index.items()
+        if _is_arabic_page_number(page_printed)
+    }
+
+
 def _derive_page_offset(page_printed_by_pdf_index):
     """Derive a constant page_pdf->page_printed offset from captured samples.
 
@@ -945,7 +954,8 @@ def _derive_page_offset(page_printed_by_pdf_index):
     Unanimity is not special-cased: a unanimous set is simply one with 100%
     agreement and no dissenters, so `_dominant_page_offset` returns it by
     the same path. Callers that need to know WHICH samples dissented use
-    `_page_offset_outliers`.
+    `_page_offset_outliers`; callers that need to know WHY a set was
+    refused use `_page_offset_refusal`.
 
     Args:
         page_printed_by_pdf_index: dict of PDF page index -> printed page
@@ -954,15 +964,30 @@ def _derive_page_offset(page_printed_by_pdf_index):
     Returns:
         (int | None, bool)
     """
-    by_index = {
-        page_pdf: int(page_printed) - page_pdf
-        for page_pdf, page_printed in page_printed_by_pdf_index.items()
-        if _is_arabic_page_number(page_printed)
-    }
-    if len(by_index) < 3:
+    by_index = _page_offset_samples(page_printed_by_pdf_index)
+    if len(by_index) < _OFFSET_MIN_SAMPLES:
         return (None, False)
-    dominant = _dominant_page_offset(by_index)
+    dominant, _ = _dominant_page_offset(by_index)
     return (dominant, True) if dominant is not None else (None, False)
+
+
+def _page_offset_refusal(page_printed_by_pdf_index):
+    """Why interpolation was refused, in one operator-readable clause.
+
+    Returns None when an offset WAS derived. The single worst failure mode
+    this module has shipped is a book emerging with 14% page coverage and an
+    empty `warnings` list: the operator sees a bad number and no account of
+    it, and cannot tell a sparse capture from a refused consensus. Every
+    refusal path here has a sentence attached for that reason.
+    """
+    by_index = _page_offset_samples(page_printed_by_pdf_index)
+    if len(by_index) < _OFFSET_MIN_SAMPLES:
+        return (
+            f"only {len(by_index)} arabic printed page number(s) were "
+            f"captured; {_OFFSET_MIN_SAMPLES} are needed to establish an offset"
+        )
+    _, reason = _dominant_page_offset(by_index)
+    return reason
 
 
 # A lone sample disagreeing with hundreds of others is an OCR misread of one
@@ -978,35 +1003,80 @@ def _derive_page_offset(page_printed_by_pdf_index):
 # RUN of samples at the new offset, never isolated singletons. That
 # distinction is what keeps this from silently flattening a real second
 # numbering sequence into a wrong one.
-# This threshold also sets the floor on sample size: any dissent at all
-# needs 20+ samples to stay above 0.95 (d/n <= 0.05), so a separate
-# minimum-samples guard would be unreachable and is deliberately absent
-# rather than sitting here implying protection it never provides.
-_OFFSET_CONSENSUS_MIN_AGREEMENT = 0.95
+#
+# The agreement bar was 0.95, which made any dissent at all require 20+
+# samples. A home scan captures folios sparsely — the folio usually sits
+# beside a running head and is read as part of it — so 20 samples is a bar
+# a whole class of real books cannot clear. Landsberg's Tao of Coaching
+# captured 18 folios; 17 agreed on -9 across the entire body and the
+# eighteenth was a numbered-list item lifted off an appendix opener. At
+# 0.95 that book (94.4% agreement) was refused and shipped with 14%
+# coverage and no printed page numbers at all.
+#
+# 0.85 is chosen over the 0.80 first cut proposed in issue #28 because 0.80
+# admits a case this module already refuses on purpose: 7 scattered
+# dissenters in 40 samples (82.5%) that all land on the SAME alternative
+# offset. That is a competing numbering hypothesis, not seven independent
+# misreads, and the run guard cannot catch it because the dissenters are
+# spread out. 0.85 is the loosest bar that admits Landsberg while keeping
+# every disagreement pattern the existing tests pin down.
+_OFFSET_CONSENSUS_MIN_AGREEMENT = 0.85
+# Below this many samples, unanimity is required. At 0.95 a minimum-samples
+# guard was unreachable (the ratio always bit first) and was deliberately
+# left out; at 0.85 it bites, and it should: a 6-to-1 split is not a
+# consensus with an outlier, it is a small sample where a genuine second
+# sequence and an OCR misread are indistinguishable.
+_OFFSET_DISSENT_MIN_SAMPLES = 8
+# Fewer than this many arabic samples and no offset is derived at all.
+_OFFSET_MIN_SAMPLES = 3
 # Two dissenters within this many sheets of each other count as a run.
 _OFFSET_DISSENT_RUN_GAP = 2
 
 
 def _dominant_page_offset(offset_by_pdf_index):
-    """Return the consensus offset, or None if the disagreement is real.
+    """Return (consensus offset, refusal reason).
+
+    Exactly one of the two is None: an adopted offset carries no reason, a
+    refusal carries no offset. The reason exists so callers can tell the
+    operator WHY a book lost its page numbering instead of leaving an empty
+    `warnings` list next to bad coverage.
 
     Args:
         offset_by_pdf_index: dict of PDF page index -> (printed - pdf)
 
     Returns:
-        int | None
+        (int | None, str | None)
     """
     counts = collections.Counter(offset_by_pdf_index.values())
     dominant, agreeing = counts.most_common(1)[0]
     total = len(offset_by_pdf_index)
+    dissenting = total - agreeing
     if agreeing / total < _OFFSET_CONSENSUS_MIN_AGREEMENT:
-        return None
+        return (None, (
+            f"the best-supported offset {dominant:+d} is carried by only "
+            f"{agreeing} of {total} captured folios "
+            f"({agreeing / total:.0%}, below the "
+            f"{_OFFSET_CONSENSUS_MIN_AGREEMENT:.0%} consensus bar), so the "
+            f"disagreement is too broad to be OCR noise"
+        ))
+    if dissenting and total < _OFFSET_DISSENT_MIN_SAMPLES:
+        return (None, (
+            f"{agreeing} of {total} captured folios agree on offset "
+            f"{dominant:+d}, but under {_OFFSET_DISSENT_MIN_SAMPLES} samples "
+            f"a dissenting folio cannot be told apart from a second "
+            f"numbering sequence, so unanimity is required"
+        ))
     dissenters = sorted(i for i, o in offset_by_pdf_index.items() if o != dominant)
     # Any two dissenters close together are a numbering change, not noise.
     for earlier, later in zip(dissenters, dissenters[1:]):
         if later - earlier <= _OFFSET_DISSENT_RUN_GAP:
-            return None
-    return dominant
+            return (None, (
+                f"pdf pages {earlier} and {later} both disagree with offset "
+                f"{dominant:+d} and are within {_OFFSET_DISSENT_RUN_GAP} "
+                f"sheets of each other; adjacent dissent is the signature of "
+                f"a renumbering or a page-order defect, not an OCR misread"
+            ))
+    return (dominant, None)
 
 
 def _page_offset_outliers(page_printed_by_pdf_index, offset):
@@ -2745,6 +2815,29 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
         for page_pdf, _, page_printed in cleaned_pages if page_printed
     }
     page_printed_offset, page_printed_offset_consistent = _derive_page_offset(page_printed_by_pdf_index)
+    # Captured-but-contradicting folios are misreads, exactly as on the
+    # marker path. Drop them so interpolation supplies the right number
+    # instead of publishing a corrupted one with full confidence, and so
+    # the span below is not stretched by a corrupted sample.
+    misread_pdf_indices = _page_offset_outliers(
+        page_printed_by_pdf_index,
+        page_printed_offset if page_printed_offset_consistent else None,
+    )
+    for page_pdf in sorted(misread_pdf_indices):
+        report.warnings.append(
+            f"page_pdf={page_pdf}: captured printed page "
+            f"'{page_printed_by_pdf_index[page_pdf]}' contradicts the book's "
+            f"offset {page_printed_offset:+d}; treated as an OCR misread and "
+            f"replaced by the interpolated value"
+        )
+        del page_printed_by_pdf_index[page_pdf]
+    if not page_printed_offset_consistent and page_printed_by_pdf_index:
+        report.warnings.append(
+            "no page_pdf->page_printed offset could be established: "
+            + (_page_offset_refusal(page_printed_by_pdf_index) or "")
+            + "; pages without a captured printed page number were left "
+            "addressable by pdf page only"
+        )
     # Interpolation is permitted only BETWEEN captured samples. Outside that
     # span there is no evidence the offset still holds — endnotes or a second
     # numbering sequence past the last sample contribute no samples, so they
@@ -2823,6 +2916,8 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
                 skipped_toc_pages += 1
                 log.debug("Skipping broken TOC page %d", page_num)
                 continue
+            # A misread folio must not be emitted OR counted as captured.
+            page_printed = page_printed_by_pdf_index.get(page_num)
             effective_page_printed = page_printed
             if (effective_page_printed is None
                     and page_printed_offset_consistent
@@ -2945,7 +3040,7 @@ def _rewrite_marker_page_locators(target, report):
     # interpolation can supply the right number, and so the span below is
     # not stretched by a corrupted sample.
     misread = _page_offset_outliers(page_printed_by_index, offset if offset_consistent else None)
-    for index in misread:
+    for index in sorted(misread):
         report.warnings.append(
             f"page_pdf={index}: captured printed page "
             f"'{page_printed_by_index[index]}' contradicts the book's "
@@ -2953,6 +3048,14 @@ def _rewrite_marker_page_locators(target, report):
             f"by the interpolated value"
         )
         del page_printed_by_index[index]
+
+    if not offset_consistent and page_printed_by_index:
+        report.warnings.append(
+            "no page_pdf->page_printed offset could be established: "
+            + (_page_offset_refusal(page_printed_by_index) or "")
+            + "; pages without a captured printed page number were left "
+            "addressable by pdf page only"
+        )
 
     arabic = _arabic_page_pdf_indices(page_printed_by_index)
     span = (min(arabic), max(arabic)) if arabic else None

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -53,6 +53,7 @@ def build_page_printed_pdf(
     offset: int = -4,
     skip_page_printed_on: tuple = (),
     body_only_footer_on: tuple = (),
+    misread_page_printed_on: dict = None,
     name: str = "page_printed.pdf",
 ) -> Path:
     """Build a PDF whose pages carry a printed page number in the footer.
@@ -74,17 +75,25 @@ def build_page_printed_pdf(
     After header stripping those pages clean to nothing and are dropped
     before a locator is emitted, so they must not count toward the
     page_printed_coverage denominator.
+
+    `misread_page_printed_on` maps a PDF page to the WRONG string printed
+    in its footer — a digit OCR'd badly, or a body numeral lifted off an
+    appendix opener. Those pages are captured with full confidence and are
+    the ones the consensus rule must suppress rather than publish.
     """
     out = tmp_path / name
     doc = fitz.open()
     skip = set(skip_page_printed_on)
     footer_only = set(body_only_footer_on)
+    misread = dict(misread_page_printed_on or {})
     for i in range(1, pages + 1):
         page = doc.new_page(width=612, height=792)
         if i not in footer_only:
             page.insert_text((72, 100), f"Body text for page {i}.")
         page_printed = i + offset
-        if page_printed >= 1 and i not in skip:
+        if i in misread:
+            page.insert_text((300, 740), str(misread[i]))
+        elif page_printed >= 1 and i not in skip:
             page.insert_text((300, 740), str(page_printed))
     doc.save(str(out))
     doc.close()

--- a/tests/test_marker_page_locators.py
+++ b/tests/test_marker_page_locators.py
@@ -330,14 +330,31 @@ def test_weak_agreement_refuses():
     assert convert._derive_page_offset(s) == (None, False)
 
 
-def test_small_non_unanimous_sample_sets_cannot_reach_consensus():
-    """Below 20 samples any dissent drops agreement under the threshold, so
-    the original strict rule still governs small books. Documented as a
-    property rather than a separate guard, because a minimum-samples check
-    would be unreachable."""
-    for n in (5, 10, 19):
+def test_tiny_sample_sets_still_require_unanimity():
+    """Under _OFFSET_DISSENT_MIN_SAMPLES, one dissenter still refuses.
+
+    A 6-to-1 split is not a consensus with an outlier; at that size a real
+    second numbering sequence and an OCR misread look identical, so the
+    strict rule still governs small books.
+    """
+    for n in range(3, convert._OFFSET_DISSENT_MIN_SAMPLES):
         s = samples(-15, range(20, 20 + n), {21: 999})
         assert convert._derive_page_offset(s) == (None, False), n
+        assert convert._page_offset_refusal(s), n
+    # At n=7 the ratio alone would have passed (6/7 = 86%); the
+    # minimum-samples guard is what refuses, and it says so. Below 7 the
+    # ratio bites first, which is why this asserts one size, not the range.
+    s = samples(-15, range(20, 27), {21: 999})
+    assert "unanimity is required" in convert._page_offset_refusal(s)
+
+
+def test_dissent_is_tolerated_at_and_above_the_minimum_sample_size():
+    """One sheet above the floor, an isolated misread stops blocking."""
+    n = convert._OFFSET_DISSENT_MIN_SAMPLES
+    s = samples(-15, range(20, 20 + n), {21: 999})
+    assert convert._derive_page_offset(s) == (-15, True)
+    assert convert._page_offset_outliers(s, -15) == {21}
+    assert convert._page_offset_refusal(s) is None
 
 
 def test_unanimous_samples_are_unaffected():
@@ -349,6 +366,135 @@ def test_unanimous_samples_are_unaffected():
 def test_outliers_are_empty_when_no_offset_was_derived():
     s = samples(-15, range(20, 60), {54: 30, 55: 31})
     assert convert._page_offset_outliers(s, None) == set()
+
+
+# --- Landsberg, The Tao of Coaching (issue #28) -----------------------------
+#
+# A 136-sheet home scan. 18 folios captured; 17 agree on offset -9 across
+# sheets 26->134 — the whole body. The eighteenth reads `pdf 115 -> printed
+# 2`: sheet 115 is headed "Appendix 1" above a numbered list, and the
+# capture lifted a list numeral. Sheet 115 really prints page 106.
+#
+# 17/18 is 94.4% agreement. Under the old 0.95 bar that book was refused,
+# shipping page_printed_coverage 0.1397, offset null — and warnings [], so
+# nothing told the operator why. That empty list is the part of the old
+# behaviour this section exists to keep dead.
+
+# 17 agreeing sheets spread across the body, none within the run gap of 115.
+LANDSBERG_AGREEING = [26, 32, 40, 48, 55, 62, 68, 75, 82, 89,
+                      95, 102, 108, 120, 126, 130, 134]
+LANDSBERG_OFFSET = -9
+LANDSBERG_MISREAD_SHEET = 115
+
+
+def landsberg_samples():
+    s = samples(LANDSBERG_OFFSET, LANDSBERG_AGREEING)
+    s[LANDSBERG_MISREAD_SHEET] = "2"        # really prints 106
+    return s
+
+
+def test_landsberg_single_scattered_outlier_reaches_consensus():
+    s = landsberg_samples()
+    assert len(s) == 18
+    assert convert._derive_page_offset(s) == (LANDSBERG_OFFSET, True)
+    assert convert._page_offset_outliers(s, LANDSBERG_OFFSET) == {
+        LANDSBERG_MISREAD_SHEET
+    }
+    assert convert._page_offset_refusal(s) is None
+
+
+def landsberg_marker_text():
+    """Sheets 26-134, folios on the 18 captured pages and nowhere else."""
+    captured = landsberg_samples()
+    return "".join(
+        marker_page(sheet, "The Tao Of Coaching", *(
+            [captured[sheet]] if sheet in captured else []
+        ), f"Body of sheet {sheet}.")
+        for sheet in range(26, 135)
+    )
+
+
+def test_landsberg_interpolates_and_warns_about_the_misread(tmp_path):
+    """End to end: the book gets its page numbering, and says what it dropped."""
+    out, report = _rewrite(tmp_path, landsberg_marker_text())
+
+    assert report.page_printed_offset == LANDSBERG_OFFSET
+    assert report.page_printed_offset_consistent is True
+    # The misread is replaced by the interpolated truth, not published.
+    assert "<!-- page_pdf=115 page_printed=106 -->" in out
+    assert "<!-- page_pdf=115 page_printed=2 -->" not in out
+    # Sheets between samples that captured nothing get an address.
+    assert "<!-- page_pdf=27 page_printed=18 -->" in out
+    assert "<!-- page_pdf=133 page_printed=124 -->" in out
+    # Only the 17 surviving captures count as captured; coverage is the
+    # whole span, not the 14% the old rule shipped.
+    assert report.page_printed_count == len(LANDSBERG_AGREEING)
+    assert report.page_locator_count == 109
+    assert report.page_numbering == "printed"
+
+    misread_warnings = [w for w in report.warnings if "page_pdf=115" in w]
+    assert len(misread_warnings) == 1
+    assert "OCR misread" in misread_warnings[0]
+    assert "offset -9" in misread_warnings[0]
+
+
+# --- refusals must always say why ------------------------------------------
+
+
+def test_ambiguous_split_refuses_and_warns(tmp_path):
+    """A 50/50 split between two offsets is not a consensus with outliers.
+
+    Neither offset can claim the book, so nothing is interpolated — and the
+    operator is told that rather than left with an empty warnings list.
+    """
+    s = samples(-9, range(20, 44, 2))               # 12 samples, offset -9
+    for sheet in range(20, 44, 4):                  # 6 of them, offset -20
+        s[sheet] = str(sheet - 20)
+    assert len(s) == 12
+    assert convert._derive_page_offset(s) == (None, False)
+    reason = convert._page_offset_refusal(s)
+    assert "consensus bar" in reason
+    assert "6 of 12" in reason
+
+    text = "".join(
+        marker_page(sheet, "Running Head", *([s[sheet]] if sheet in s else []),
+                    f"Body of sheet {sheet}.")
+        for sheet in range(20, 44)
+    )
+    _, report = _rewrite(tmp_path, text)
+    assert report.page_printed_offset_consistent is False
+    assert report.page_printed_offset is None
+    refusals = [w for w in report.warnings if "no page_pdf->page_printed offset" in w]
+    assert len(refusals) == 1
+    assert "consensus bar" in refusals[0]
+
+
+def test_contiguous_run_refuses_and_names_the_adjacent_sheets(tmp_path):
+    """The regression guard, now audible.
+
+    A duplex-ADF fault once transposed sixteen sheets of another book in
+    adjacent pairs. Adjacent dissent must keep blocking interpolation — and
+    must say which sheets triggered it, so the operator can go look.
+    """
+    s = samples(-15, range(20, 60), {54: 30, 55: 31})
+    assert convert._derive_page_offset(s) == (None, False)
+    reason = convert._page_offset_refusal(s)
+    assert "54" in reason and "55" in reason
+    assert "renumbering or a page-order defect" in reason
+
+    text = "".join(
+        marker_page(sheet, "Running Head", *([s[sheet]] if sheet in s else []),
+                    f"Body of sheet {sheet}.")
+        for sheet in range(20, 60)
+    )
+    out, report = _rewrite(tmp_path, text)
+    assert report.page_printed_offset_consistent is False
+    # Nothing is interpolated: sheet 54's neighbours captured 39 and 41, and
+    # the gap between them must NOT be filled in.
+    assert "<!-- page_pdf=54 page_printed=30 -->" in out
+    refusals = [w for w in report.warnings if "no page_pdf->page_printed offset" in w]
+    assert len(refusals) == 1
+    assert "renumbering or a page-order defect" in refusals[0]
 
 
 # --- flag plumbing ---------------------------------------------------------

--- a/tests/test_page_locators.py
+++ b/tests/test_page_locators.py
@@ -268,6 +268,14 @@ def test_renumbering_book_gets_no_interpolation_in_markdown(tmp_path):
     # numbering runs we must emit `none`, never a guess.
     assert "<!-- page_pdf=12 page_printed=none -->" in md
     assert "<!-- page_pdf=14 page_printed=none -->" in md
+    # A refusal must never be silent. Shipping 14% coverage with an empty
+    # warnings list is what sent issue #28 to a human to diagnose by hand.
+    # The two runs are 6 samples each, so this refuses on the agreement bar
+    # (the run guard never gets a chance) — and says which bar it hit.
+    refusals = [w for w in report.warnings if "no page_pdf->page_printed offset" in w]
+    assert len(refusals) == 1
+    assert "consensus bar" in refusals[0]
+    assert "6 of 12" in refusals[0]
     # PDF pages 1-2 carry no printed number at all and stay `none`.
     assert "<!-- page_pdf=1 page_printed=none -->" in md
     assert "<!-- page_pdf=2 page_printed=none -->" in md
@@ -589,3 +597,38 @@ def test_convert_book_epub_route_produces_a_sidecar(tmp_path):
     # Cleanup is deliberately skipped on the epub route (it repairs PDF
     # extraction artifacts), so the sidecar must not claim it ran.
     assert not data.get("cleaned")
+
+
+def test_misread_folio_is_suppressed_and_warned_in_markdown(tmp_path):
+    """A captured-but-wrong folio must not be published on the pymupdf path.
+
+    A captured printed number is normally the most trustworthy address the
+    converter has, so a corrupted one goes out with full confidence and a
+    reader cannot tell. Consensus lets interpolation supply the truth
+    instead — and the operator is told which page was overruled.
+    """
+    import convert
+    from tests import fixtures
+
+    # PDF pages 5-20 print 1-16 (offset -4). Page 12 prints "99" instead of 8,
+    # standing in for a body numeral lifted off an appendix opener.
+    pdf = fixtures.build_page_printed_pdf(
+        tmp_path, pages=20, offset=-4, misread_page_printed_on={12: "99"}
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    md = (out_dir / f"{pdf.stem}.md").read_text(encoding="utf-8")
+
+    # 15 of 16 samples agree on -4; the sixteenth is scattered, so it loses.
+    assert report.page_printed_offset == -4
+    assert report.page_printed_offset_consistent is True
+    assert "<!-- page_pdf=12 page_printed=8 -->" in md
+    assert "page_printed=99" not in md
+    # The suppressed capture is not counted as captured.
+    assert report.page_printed_count == 15
+
+    misread = [w for w in report.warnings if "page_pdf=12" in w]
+    assert len(misread) == 1
+    assert "'99'" in misread[0]
+    assert "OCR misread" in misread[0]


### PR DESCRIPTION
Closes #28.

## The rule

A `page_pdf -> page_printed` offset is adopted when **all** of:

| | |
|---|---|
| Sample floor | ≥ 3 arabic captured folios (unchanged) |
| Agreement | ≥ **85%** of samples share one offset (was 95%) |
| Dissent floor | dissent is tolerated only at ≥ **8** samples; below that, unanimity (new) |
| Adjacency | no two dissenters within **2 sheets** of each other (unchanged) |

Adjacency is measured on sorted dissenting PDF sheet indices: any consecutive pair with `later - earlier <= 2` refuses the whole book. Roman folios never participate.

Folios contradicting an adopted offset are suppressed, replaced by the interpolated value, not counted as captured, and warned about — one warning per outlier. Refusals emit one warning naming which bar was hit.

## Why 0.85, not the 0.80 in the issue

0.80 admits a case this module already refuses on purpose, pinned by `test_weak_agreement_refuses`: 7 scattered dissenters in 40 samples (82.5%) that all land on the **same** alternative offset. Seven independent OCR misreads do not agree with each other; that shape is a competing numbering hypothesis, and the run guard cannot see it because the dissenters are deliberately spread beyond the gap. 0.85 is the loosest bar that admits Landsberg (94.4%) while keeping every disagreement pattern the existing tests pin down.

## Why the new 8-sample floor

At 0.95, a minimum-samples guard was unreachable — the ratio always bit first — and the old code says so in a comment, refusing to imply protection it never gave. At 0.85 it bites at n=7 (6/7 = 86% would otherwise pass). It should: a 6-to-1 split is not a consensus with an outlier, it is a sample too small to tell a misread from a genuine second sequence.

## Why the pymupdf path changed too

The marker path already suppressed contradicting folios; pymupdf never did. Lowering the bar means pymupdf now reaches consensus on books that previously refused outright — and without suppression it would publish the misread folio verbatim, with full confidence, on the one field a reader has no way to check. Skipping this would have converted the bug into a quieter one.

## The regression guard is untouched

Two dissenters within 2 sheets still refuse the whole book. `test_contiguous_dissent_is_a_renumbering_and_still_refuses` and `test_two_adjacent_dissenters_are_enough_to_refuse` pass unmodified; a new test additionally asserts the refusal names the adjacent sheets.

## Tests

`.venv` (Python 3.9.6), `python -m pytest tests/`:

```
236 passed, 8 skipped
```

Before this change the same suite was `229 passed, 8 skipped, 1 failed` — the failure being `test_small_non_unanimous_sample_sets_cannot_reach_consensus`, which asserted the emergent 20-sample property this PR deliberately replaces. It is rewritten as `test_tiny_sample_sets_still_require_unanimity` against the explicit floor.

Mutation-checked: reverting only `_OFFSET_CONSENSUS_MIN_AGREEMENT` to 0.95 fails 5 tests, 4 of them new.

New coverage:

- `test_landsberg_single_scattered_outlier_reaches_consensus` — the real 17-of-18 data
- `test_landsberg_interpolates_and_warns_about_the_misread` — end to end over sheets 26–134: `page_pdf=115` emits `page_printed=106`, never `2`; `page_printed_count == 17`; one warning naming sheet 115
- `test_ambiguous_split_refuses_and_warns` — 6/12 vs 6/12, refuses, warns "consensus bar"
- `test_contiguous_run_refuses_and_names_the_adjacent_sheets` — regression guard, plus the warning
- `test_dissent_is_tolerated_at_and_above_the_minimum_sample_size` / `test_tiny_sample_sets_still_require_unanimity` — both sides of the 8-sample floor
- `test_misread_folio_is_suppressed_and_warned_in_markdown` — the pymupdf half
- `test_renumbering_book_gets_no_interpolation_in_markdown` extended to assert the refusal warning

No OCR or marker conversion was run; every case is constructed from locator data.

## Not addressed

The issue's secondary observation — capture failing wherever the folio sits beside a running head, which is the independent cause of the 14% capture rate — is a margin-crop problem in a different part of the pipeline and wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)