### PR TITLE
Read the folio when it shares a line with the running head

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ as a page number a reader would trust. Every refusal is likewise reported
 in `warnings` with its reason, so low coverage always comes with an
 account of itself.
 
+A folio does not have to stand alone on its line to be read. Many editions
+set it on the same line as the running head, pinned to the outer edge of the
+spread — `52 THE TAO OF COACHING` on a verso, `MOTIVATING 67` on a recto. A
+numeral is lifted out of such a line only when it is the first or last token
+on it, when what remains is a running head already seen on three or more
+pages, and when the line as a whole does *not* repeat — a folio changes
+every page, so a band line that repeats verbatim has a constant number in it
+(a year in the title, a part or chapter number) and that number belongs to
+the title, not to the pagination. Roman numerals are never lifted out of a
+shared line. A folio standing alone always wins over one sharing a line.
+
 Check coverage after any conversion:
 
     jq '.page_numbering, .page_printed_coverage, .page_printed_offset_consistent' output/<Title>.report.json
@@ -381,13 +392,13 @@ Note that `ps aux | grep marker_single` returns **nothing** even while marker is
 
 ## Known limitations
 
-### Folio capture degrades when the page number sits beside a running head
+### Folio capture is still partial when the page number sits beside a running head
 
-Page-number capture reads a crop of each page's margins. It is reliable when the folio stands alone and unreliable when the folio shares its line with a running head — on one 136-page scan, capture succeeded almost exclusively on chapter openers and reached only 19 of 136 pages. Tracked in [#31](https://github.com/AndySparks/book-convert/issues/31).
+A folio sharing its line with a running head is now read (see *Page numbers* above), but only where the head beside it recurs on at least three pages. That bar is what keeps a line of prose from being mistaken for pagination, and it is paid for on short chapters: a book whose recto head is the *chapter* title, running two or three pages before the next chapter starts, loses those rectos. On Landsberg's *The Tao of Coaching* the versos all carry the book title and are read; the rectos carry chapter titles and roughly half fall under the bar. Capture on that scan goes from 19 of 136 to about 52 — enough to rest the offset on the whole body instead of on nine chapter openers, not enough to call the problem closed. Tracked in [#31](https://github.com/AndySparks/book-convert/issues/31).
 
 Two consequences worth knowing when you read a sidecar:
 
-- Low `page_printed_coverage` on a clean scan usually means this, not a source without printed page numbers.
+- Low `page_printed_coverage` on a clean scan usually means this, not a source without printed page numbers. What matters more than the coverage figure is `page_printed_offset_consistent`: with a consistent offset, the uncaptured pages are interpolated and get the same number they would have had.
 - **Folio position varies by edition, not just by page.** Some books run the number at the foot of every page; others at the top outer corner. There is no safe default — render both margin bands and look before concluding a source has no page numbers.
 
 ### EPUB has no pages

--- a/convert.py
+++ b/convert.py
@@ -1184,6 +1184,87 @@ _MARKER_HEADER_SCAN_LINES = 3
 # and recto usually carry different heads, so a book alternates between two.
 _MARKER_HEADER_MIN_REPEATS = 3
 
+# --- folios sharing a line with a running head -----------------------------
+#
+# On many editions the folio does not stand alone: it sits on the same line
+# as the running head, pinned to the OUTER edge of the spread — leading on a
+# verso ("52 THE TAO OF COACHING"), trailing on a recto ("MOTIVATING 67").
+# `_MARKER_FOLIO_RE` anchors both ends, so every one of those lines was
+# discarded whole. On Landsberg's *The Tao of Coaching* that cost 117 of 136
+# pages: the folios that survived were almost all chapter openers, the one
+# place the edition sets the folio alone.
+#
+# The extraction rule is deliberately narrow, because a wrong folio is worse
+# than no folio — it is published as the number printed on the page, on the
+# one field a reader has no way to check. A numeral is lifted out of a band
+# line only when ALL of:
+#
+#   1. it is the first or the last token on the line (a folio is pinned to
+#      the page edge; a number in the middle of a head is part of the title);
+#   2. what remains, with the numeral removed, is RECURRING FURNITURE — the
+#      same residue appears in the same band on >= _MARKER_HEADER_MIN_REPEATS
+#      pages. This is the frequency argument the module already rests on for
+#      stripping: a running head repeats, a line of prose does not;
+#   3. the line as a whole does NOT recur. A folio changes every page, so a
+#      band line that repeats verbatim has a CONSTANT number in it — a year
+#      in the title, a part or chapter number — and is furniture entire;
+#   4. the residue contains a letter, so "52 1984" (two numerals, no head)
+#      is refused rather than guessed at;
+#   5. only ONE end of the line qualifies. If stripping the leading numeral
+#      and stripping the trailing numeral both leave known furniture, the
+#      line is ambiguous and yields nothing.
+#
+# Roman folios are NOT read out of a shared line. A bag of roman letters
+# matches ordinary words ("civil", "mild", "did"), and unlike the arabic
+# case there is no digit shape to lean on; roman front matter sets the folio
+# alone often enough that the trade is not worth the false positives.
+_MARKER_EMBEDDED_FOLIO_LEADING_RE = re.compile(r'^(\d{1,4})\s+(\S.*)$')
+_MARKER_EMBEDDED_FOLIO_TRAILING_RE = re.compile(r'^(.*\S)\s+(\d{1,4})$')
+
+# Line shapes that are never a running head: markdown headings and block
+# quotes are content by construction, images carry no folio, and a table row
+# ends in numbers for reasons that have nothing to do with pagination.
+_MARKER_NOT_A_RUNNING_HEAD_RE = re.compile(r'^(?:#{1,6}\s|>|!\[)')
+
+_HAS_LETTER_RE = re.compile(r'[^\W\d_]')
+
+
+def _embedded_folio_candidates(line):
+    """(folio, running-head residue) pairs for a band line, edge tokens only.
+
+    Shape only — this says nothing about whether the residue is furniture.
+    Callers must confirm that against the recurring-line set; see
+    `_accepted_embedded_folio`.
+    """
+    stripped = line.strip()
+    if not stripped or _MARKER_NOT_A_RUNNING_HEAD_RE.match(stripped):
+        return []
+    if '|' in stripped:
+        return []
+    if _is_marker_folio(stripped):
+        return []          # a bare folio: the existing path already reads it
+    out = []
+    m = _MARKER_EMBEDDED_FOLIO_LEADING_RE.match(stripped)
+    if m and int(m.group(1)) >= 1 and _HAS_LETTER_RE.search(m.group(2)):
+        out.append((m.group(1), m.group(2).strip()))
+    m = _MARKER_EMBEDDED_FOLIO_TRAILING_RE.match(stripped)
+    if m and int(m.group(2)) >= 1 and _HAS_LETTER_RE.search(m.group(1)):
+        out.append((m.group(2), m.group(1).strip()))
+    return out
+
+
+def _accepted_embedded_folio(line, known):
+    """The folio in a running-head line, or None if the line is not one.
+
+    `known` is the recurring-furniture set for the band this line came from.
+    """
+    stripped = line.strip()
+    if stripped in known:
+        return None        # recurs verbatim: any number in it is constant
+    accepted = [folio for folio, residue in _embedded_folio_candidates(stripped)
+                if residue in known]
+    return accepted[0] if len(accepted) == 1 else None
+
 
 def _split_marker_pages(text):
     """Split paginated marker output into (page_index, page_text) pairs.
@@ -1237,6 +1318,13 @@ def _marker_recurring_lines(pages, from_end=False):
     mistaken for furniture, at the cost of leaving a head that genuinely
     appears twice — the safe direction to err, since a stray head in the body
     is visible while deleted body text is not.
+
+    Lines are counted twice over: verbatim, and with an edge numeral removed.
+    The second form is what lets a head that ALWAYS carries its folio
+    ("52 THE TAO OF COACHING", "MOTIVATING 67") be recognised at all — the
+    whole line never repeats, but the residue repeats on every page of the
+    book. Both forms land in one set; membership means "this string is
+    furniture", and the caller decides what to do with the numeral.
     """
     counts = collections.Counter()
     for _index, page in pages:
@@ -1247,6 +1335,8 @@ def _marker_recurring_lines(pages, from_end=False):
             # by shape, not by frequency.
             if stripped and not _is_marker_folio(stripped):
                 seen.add(stripped)
+                seen.update(residue for _folio, residue
+                            in _embedded_folio_candidates(stripped))
         counts.update(seen)
     return {line for line, n in counts.items() if n >= _MARKER_HEADER_MIN_REPEATS}
 
@@ -1264,8 +1354,15 @@ def _strip_marker_page_furniture(page_text, header_lines, footer_lines):
     therefore disagree — a folio may be captured and left in the body — and
     that is the safe direction: a stray number in the text is visible,
     whereas deleting a line that turned out to be prose is not.
+
+    A folio standing alone is preferred over one shared with a running head,
+    in both bands, before the shared-line rule is tried at all. That ordering
+    is what makes this change incapable of altering any book whose folios
+    already stand alone: on such a page the first pass has already returned.
     """
     lines = page_text.split('\n')
+    head_band = _band_lines(page_text)
+    foot_band = _band_lines(page_text, from_end=True)
 
     def first_folio(band):
         for line in band:
@@ -1273,14 +1370,27 @@ def _strip_marker_page_furniture(page_text, header_lines, footer_lines):
                 return line.strip()
         return None
 
-    folio = (first_folio(_band_lines(page_text))
-             or first_folio(_band_lines(page_text, from_end=True)))
+    def first_embedded_folio(band, known):
+        for line in band:
+            folio = _accepted_embedded_folio(line, known)
+            if folio:
+                return folio
+        return None
+
+    folio = (first_folio(head_band)
+             or first_folio(foot_band)
+             or first_embedded_folio(head_band, header_lines)
+             or first_embedded_folio(foot_band, footer_lines))
 
     def strippable(line, known):
         stripped = line.strip()
         if _MARKDOWN_HEADING_RE.match(stripped):
             return False
-        return _is_marker_folio(stripped) or stripped in known
+        if _is_marker_folio(stripped) or stripped in known:
+            return True
+        # A running head that carries its folio is furniture entire: the
+        # residue is known, so the line is recognised and goes with it.
+        return _accepted_embedded_folio(stripped, known) is not None
 
     start, consumed = 0, 0
     while start < len(lines) and consumed < _MARKER_HEADER_SCAN_LINES:

--- a/tests/test_marker_page_locators.py
+++ b/tests/test_marker_page_locators.py
@@ -164,6 +164,179 @@ def test_roman_front_matter_folio_is_captured():
     assert body.strip() == "Preface text."
 
 
+# --- folios sharing a line with a running head -----------------------------
+#
+# Landsberg's *The Tao of Coaching* sets the folio at the top outer corner of
+# every ordinary page, on the same line as the running head — "52 THE TAO OF
+# COACHING" on a verso, "MOTIVATING 67" on a recto. Only chapter openers set
+# it alone, so a rule anchored to a bare number captured 19 of 136 pages and
+# the pages it captured were almost all chapter openers.
+#
+# Lifting the numeral out is cheap; lifting the WRONG numeral out is the
+# expensive part, because a folio is published as the number printed on the
+# page and a reader has no way to check it. The numeral must be at the page
+# edge, what remains must be recognised furniture, and the line as a whole
+# must NOT recur — a folio changes every page, so a band line that repeats
+# verbatim has a constant number in it and the number is part of the title.
+
+
+def body_for(sheet):
+    """Page body distinct per sheet, so no body line can look like furniture."""
+    return [f"Body line {n} of sheet {sheet}." for n in range(1, 9)]
+
+
+def landsberg(sheets, offset=-9):
+    """Pages laid out like *The Tao of Coaching*: folio beside a running head,
+    pinned to the outer edge — leading on a verso, trailing on a recto."""
+    out = []
+    for sheet in sheets:
+        printed = sheet + offset
+        head = (f"{printed} THE TAO OF COACHING" if printed % 2 == 0
+                else f"MOTIVATING {printed}")
+        out.append(marker_page(sheet, head, *body_for(sheet)))
+    return "".join(out)
+
+
+def locators(text):
+    _pages, printed = convert._marker_page_locators(text)
+    return printed
+
+
+def test_folio_leading_a_running_head_on_a_verso_is_captured():
+    printed = locators(landsberg(range(60, 72)))
+    assert printed[61] == "52"          # "52 THE TAO OF COACHING"
+    assert printed[63] == "54"
+
+
+def test_folio_trailing_a_running_head_on_a_recto_is_captured():
+    printed = locators(landsberg(range(60, 72)))
+    assert printed[62] == "53"          # "MOTIVATING 53"
+    assert printed[64] == "55"
+
+
+def test_both_page_sides_are_captured_across_the_whole_book():
+    """The failure was systematic, so the fix has to be too: this book gave
+    up 19 of 136 pages, and every one of these sheets carries a folio."""
+    sheets = range(60, 96)
+    printed = locators(landsberg(sheets))
+    assert set(printed) == set(sheets)
+    assert all(int(v) - k == -9 for k, v in printed.items())
+
+
+def test_the_running_head_line_goes_with_its_folio():
+    """It is furniture entire. Left behind, "52 THE TAO OF COACHING" is a
+    stray line of page apparatus in the middle of the prose — which is what
+    the old rule actually produced, because it recognised neither half."""
+    text = landsberg(range(60, 72))
+    pages, _printed = convert._marker_page_locators(text)
+    body = dict(pages)[61]
+    assert "THE TAO OF COACHING" not in body
+    assert body.strip().startswith("Body line 1 of sheet 61.")
+
+
+def test_a_band_line_with_no_number_yields_no_folio():
+    """Some rectos in this edition carry the running head alone."""
+    text = "".join(
+        marker_page(s, "TAKING ACCOUNT OF OTHERS' SKILL AND WILL", *body_for(s))
+        for s in range(60, 66))
+    assert locators(text) == {}
+
+
+def test_a_head_whose_number_never_changes_is_a_title_not_a_folio():
+    """The false positive that matters. A year in the running head sits at
+    the page edge and reads exactly like a folio — except that it is the
+    same number on every page, and a folio never is."""
+    text = "".join(marker_page(s, "1984 AND ALL THAT", *body_for(s))
+                   for s in range(20, 26))
+    assert locators(text) == {}
+
+
+def test_a_constant_chapter_number_in_the_head_is_not_a_folio():
+    text = "".join(marker_page(s, "CHAPTER 4", *body_for(s))
+                   for s in range(20, 26))
+    assert locators(text) == {}
+
+
+def test_a_one_off_line_starting_with_a_number_is_not_a_running_head():
+    """Recurrence is the whole safety argument. "1 Introduction" opening a
+    page once is prose, or a list item, and must not be read as page 1."""
+    text = ("".join(marker_page(s, f"Some opening line for sheet {s}.",
+                                *body_for(s)) for s in range(20, 26))
+            + marker_page(26, "1 Introduction", *body_for(26)))
+    assert locators(text) == {}
+
+
+def test_a_roman_numeral_is_never_lifted_out_of_a_shared_line():
+    """A bag of roman letters matches ordinary words, and beside a running
+    head there is no digit shape to lean on. Roman front matter sets its
+    folio alone often enough that the trade is not worth taking."""
+    text = "".join(marker_page(s, f"xi{'i' * (s - 5)} THE TAO OF COACHING",
+                               *body_for(s)) for s in range(6, 12))
+    assert locators(text) == {}
+
+
+def test_a_number_at_both_ends_of_a_known_head_is_refused():
+    """Ambiguity, not a coin toss: if removing the leading numeral and
+    removing the trailing numeral both leave recognised furniture, there is
+    no evidence about which one is the folio."""
+    known = {"MOTIVATING 67", "12 MOTIVATING"}
+    assert convert._accepted_embedded_folio("12 MOTIVATING 67", known) is None
+    assert convert._accepted_embedded_folio("12 MOTIVATING 67",
+                                            {"MOTIVATING 67"}) == "12"
+
+
+def test_a_table_row_is_never_a_running_head():
+    """Its last cell is a number for reasons that have nothing to do with
+    pagination, and its shape can recur across a run of table pages.
+
+    Boyatzis's statistical appendix is pages of tables with a repeated stub
+    column and a varying final cell — the exact shape of a running head with
+    a folio, and the reason the blind margin crop was abandoned."""
+    assert convert._embedded_folio_candidates("Stage IV | 1.525 | 1612") == []
+    assert convert._embedded_folio_candidates("1612 | Stage IV | 1.525") == []
+    text = "".join(marker_page(s, f"Stage IV | 1.525 | {s - 13}", *body_for(s))
+                   for s in range(300, 306))
+    assert locators(text) == {}
+
+
+def test_a_markdown_heading_or_image_is_never_a_running_head():
+    """Content by construction: marker renders furniture as plain text, so a
+    `#` line is by definition not a head, and a figure carries no folio.
+    Both shapes recur in this edition — "# 4 Correcting common coaching
+    myths" on every chapter opener, a full-page picture on every facing page.
+
+    Belt-and-braces, and the test says so rather than implying more: the
+    edge-token regexes cannot match these lines anyway, because neither the
+    first nor the last token is a bare numeral. The exclusion exists so that
+    loosening those regexes later cannot quietly start reading headings as
+    pagination. No test claims to exercise a reachable failure here.
+    """
+    assert convert._embedded_folio_candidates("#### 4 THE MYTHS") == []
+    assert convert._embedded_folio_candidates("![](_page_59_Picture_0.jpeg)") == []
+    assert convert._embedded_folio_candidates("> 12 Quoted line") == []
+
+
+def test_a_folio_standing_alone_wins_over_one_shared_with_a_head():
+    """The ordering that makes this change unable to touch a book whose
+    folios already stand alone: the bare-folio pass runs over both bands
+    before the shared-line rule is tried at all. Here the head carries a
+    part number that would otherwise be read as the folio."""
+    text = "".join(marker_page(s, f"PART TWO {s - 500}", *body_for(s), str(s - 13))
+                   for s in range(500, 506))
+    printed = locators(text)
+    assert printed == {s: str(s - 13) for s in range(500, 506)}
+
+
+def test_a_book_with_drop_folios_alone_is_completely_unchanged():
+    """Regression guard for *Accidental Empires*, which sets the folio alone
+    at the foot of every page and already captures 0.833 of the book."""
+    text = "".join(marker_page(s, "#### ACCIDENTAL EMPIRES", *body_for(s),
+                               str(s - 13)) for s in range(100, 140))
+    printed = locators(text)
+    assert len(printed) == 40
+    assert convert._derive_page_offset(printed) == (-13, True)
+
+
 # --- _rewrite_marker_page_locators ----------------------------------------
 
 
@@ -234,6 +407,22 @@ def test_misread_folio_is_replaced_by_the_interpolated_value(tmp_path):
     assert "<!-- page_pdf=54 page_printed=30 -->" not in out
     assert any("misread" in w and "page_pdf=54" in w for w in report.warnings)
     assert report.page_printed_count == 39
+
+
+def test_landsberg_layout_ends_up_fully_citable(tmp_path):
+    """End to end, on the layout the issue is about. Every sheet carries its
+    printed number, the offset rests on the whole body rather than on the
+    chapter openers alone, and no running head survives into the prose."""
+    out, report = _rewrite(tmp_path, landsberg(range(60, 96)))
+    assert report.page_numbering == "printed"
+    assert report.page_printed_offset == -9
+    assert report.page_printed_offset_consistent is True
+    assert report.page_printed_count == 36
+    assert report.page_printed_coverage == 1.0
+    assert "<!-- page_pdf=61 page_printed=52 -->" in out
+    assert "<!-- page_pdf=62 page_printed=53 -->" in out
+    assert "THE TAO OF COACHING" not in out
+    assert report.warnings == []
 
 
 def test_rewrite_marks_unpaginated_output_as_uncitable(tmp_path):


### PR DESCRIPTION
Closes #31.

## The rule

A numeral is lifted out of a band line only when **all** of:

| | |
|---|---|
| Position | first or last token on the line — a folio is pinned to the outer edge of the spread |
| Residue is furniture | what remains, numeral removed, has been seen in the **same band** on ≥ 3 pages (`_MARKER_HEADER_MIN_REPEATS`, unchanged) |
| Line is not furniture | the line as a whole does **not** recur — a folio changes every page, so a band line repeating verbatim has a *constant* number in it |
| Residue has a letter | `52 1984` is refused, not guessed at |
| Unambiguous | if stripping the leading numeral **and** stripping the trailing numeral both leave known furniture, nothing is read |

Roman numerals are never lifted out of a shared line: a bag of roman letters matches ordinary words (`civil`, `mild`, `did`) and, unlike arabic, there is no digit shape to lean on. Roman front matter sets its folio alone often enough that the trade is not worth taking.

The mechanism is one line in `_marker_recurring_lines`: band lines are now counted **twice**, verbatim and with an edge numeral removed. `52 THE TAO OF COACHING` never repeats, but `THE TAO OF COACHING` repeats on every verso in the book. That single change is what makes the head recognisable at all — and recognising it means it now gets **stripped** too. Those lines were being left behind as stray page apparatus in the middle of the prose (visible in the shipped Landsberg markdown).

## False positives are the expensive direction

A wrong folio is published as the number printed on the page, on the one field a reader cannot check. Guards 2 and 3 are the load-bearing ones and they are complements:

- **Guard 2** (residue recurs) is the module's existing frequency argument — a running head repeats, a line of prose does not. It kills `1 Introduction` opening a page once.
- **Guard 3** (line does not recur) kills the case the issue warns about, a **running head containing digits**. `1984 AND ALL THAT` has a numeral at the page edge and a residue that recurs; what gives it away is that the number is the same on every page, and a folio never is. Same for `CHAPTER 4`.

Ordering is the third guard: `first_folio(head) or first_folio(foot) or first_embedded(head) or first_embedded(foot)`. On any page where a folio stands alone, the shared-line rule is never reached.

Anything that survives all of this still faces the #29 consensus machinery, which suppresses a capture contradicting the adopted offset. The two compose, as the issue predicted.

## Verified against real marker output — no OCR run

Both books' existing `output/*.md` were reconstructed into paginated marker documents and run through `_marker_page_locators` with the new rule enabled and disabled.

| | captures | lost | changed | new captures disagreeing with the book's offset | bodies changed |
|---|---|---|---|---|---|
| Landsberg, *The Tao of Coaching* (offset −9) | 1 → 35 | 0 | 0 | 0 | 35 (running head removed) |
| Cringely, *Accidental Empires* (offset −13, 0.833 coverage) | 3 → 3 | 0 | 0 | — | **0** |

Accidental Empires is byte-for-byte identical, capture and body alike — the regression guard the issue asks for.

The Landsberg figures are a **lower bound**: that markdown has already had its bare folios stripped, so the 18–19 chapter-opener captures aren't in the "1". A real reconversion should land near **52 of 136 (≈0.38), up from 19 (0.14)** — and, more to the point, the −9 offset would rest on ~50 samples spanning sheets 12–134 rather than on nine chapter openers.

## Scope: option 2 from the issue only, deliberately

**Option 1 (segment the margin band before OCR) is not the problem.** The issue describes capture as "a crop of each page's margins"; that blind-crop approach was tried and rejected during PR #23 and the reasoning is in `convert.py` — on Boyatzis it captured *fewer* folios than marker and polluted the samples so badly no offset could be derived. What actually runs is marker's own layout model, which already isolates the running head as a `PageHeader` block. The band was never the failure; the text rule reading it was. There is nothing to segment.

**Option 3 (feed the established offset back into failed bands) is skipped on purpose.** Once an offset is consistent, `_rewrite_marker_page_locators` already interpolates every uncaptured page in the span — and the value it emits is exactly the value a re-read confirmed against the expected number would emit. So option 3 produces **no new page number for any reader**. What it would change is `page_printed_count` and `page_printed_coverage`, by counting self-confirmed reads as independent captures. That makes the one statistic telling an operator how much evidence a book's pagination rests on report more evidence than exists. If it's wanted later it should be a separate, separately-named field, not folded into coverage.

## Limits, now in the README

Guard 2's three-page bar is paid for on short chapters. Where the recto running head is the *chapter* title and chapters run two or three pages, those rectos stay uncaptured — that is most of the Landsberg gap between 52 and 136. Loosening the bar to 2 is the obvious next lever and I did not pull it: it is the same constant that governs what gets deleted from the body, and this change already widens what that constant reaches.

## Tests

`.venv` (Python 3.9.6), `python -m pytest`:

```
287 passed, 8 skipped
```

Baseline on `main` is `272 passed, 8 skipped` — 15 new tests, no existing test modified or deleted.

Coverage: folio leading on a verso; folio trailing on a recto; both sides across a whole book; the head line leaving with its folio; a band with no number; a head with a constant year; a constant chapter number; a one-off line starting with a number; roman refused on a shared line; both-ends ambiguity; a table row with a repeated stub and varying final cell (the Boyatzis appendix hazard); folio-alone winning over a shared line; a drop-folio book unchanged; and end-to-end through `_rewrite_marker_page_locators`.

### Mutation check

Each guard was reverted independently and the suite re-run:

| Mutation | Result |
|---|---|
| Core rule reverted (no embedded folio ever accepted) | **6 failed** |
| Guard 3 removed (verbatim-recurring line accepted) | **2 failed** — both digit-in-head tests |
| Guard 2 removed (residue need not be furniture) | **2 failed** |
| Guard 5 removed (ambiguity takes the first candidate) | **1 failed** |
| Roman admitted at the leading edge | **1 failed** |
| Table-row exclusion removed | **1 failed** |
| Bare-folio-first ordering removed | **1 failed** |

One guard did **not** bite: excluding markdown headings, block quotes and images. The edge-token regexes cannot match those lines anyway, since neither the first nor the last token is a bare numeral. Rather than contrive a test around an unreachable path, the exclusion is kept as belt-and-braces against a future loosening of those regexes and its test says exactly that.

No marker or OCR conversion was run. Every case is constructed from band-text fixtures or from marker output already on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
