### PR TITLE
Never emit a reference to an asset we didn't write

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,15 +20,16 @@ The marginal cost of completeness is near zero with AI. Do the whole thing. Do i
 6. `--method docling` (Python 3.10+, use `.venv-marker`) — IBM's layout-aware pipeline
 7. `--method ocr` or `--ocr` — tesseract OCR for scanned/image-based PDFs
 8. EPUB files always route through pandoc regardless of `--method`. If the epub carries no semantic `h1`–`h6`, `epub_structure.py` derives headings from the book's own nav (`toc.ncx` / EPUB 3 nav doc), falling back to a chapter-ish CSS-class heuristic, and hands pandoc a rewritten copy from a temp dir (the source is never modified). The sidecar always declares `heading_source` (`semantic` | `nav` | `class-heuristic` | `none`) and `headings_emitted`
-9. Add `--extract-images` (pymupdf backend only) to render figures, diagrams, and raster images as PNGs in a sibling `<stem>_assets/` dir with inline markdown references
+9. **Figure extraction is on by default on every PDF backend.** Figures land in a sibling `<stem>_assets/` (pymupdf) or `<stem>_images/` (marker, pymupdf4llm) dir with inline markdown references. `--no-extract-images` converts text only and *strips* the references to the skipped figures rather than leaving them dangling. The invariant — **the output never contains a reference to a file that does not exist** — holds on every backend under every flag combination; `docs/asset-invariant.md` explains why it did not for a year
 10. A verbatim-safe **cleanup pass runs by default** on every conversion (`cleanup.py`): it de-joins dropped-space function-word joins ("thefrozen" -> "the frozen"), fixes stray-consonant citation ghosts ("—wWilliam" -> "—William"), and unwraps picture-text TOC tables while dropping OCR garble blocks. Pass `--no-clean` to skip it. The de-join needs `pyspellchecker` (in `requirements.txt`) and degrades gracefully if absent (dictionary-free repairs still run; a warning is recorded).
-11. Every conversion writes a `<stem>.report.json` sidecar: method, page counts, OCR pages, extracted assets, quality score, `cleaned`/`cleanup` stats, heading signals (EPUB), warnings
+11. Every conversion writes a `<stem>.report.json` sidecar: method, page counts, OCR pages, extracted assets, the **asset manifest** (`assets`: every file written, with the references pointing at it) and `dangling_refs_stripped`, quality score, `cleaned`/`cleanup` stats, heading signals (EPUB), warnings
 12. Converted markdown files appear in `output/`
 
 ## When helping users
 
 - If a conversion produces poor results (garbled text, missing content), first try `--method pymupdf4llm` (Python 3.10+), then `--method ocr`; `--auto-ocr` auto-retries with tesseract/marker on quality failure
-- For visually heavy books (diagrams, figures), use `--extract-images` or `--method pymupdf4llm` — both produce PNGs for figures
+- For visually heavy books (diagrams, figures), the default already keeps the figures; `--method marker` finds the most of them
+- **Never tell a consumer to pattern-match an asset filename.** `_page_N_Figure_M.jpeg` is marker's private convention. Relocating assets is done from the sidecar's `assets` manifest — `path` plus `references[].target` — which is stable across backends and across marker versions
 - If OCR output needs cleanup, help the user clean up the markdown: fix obvious OCR errors, add proper headings, remove page artifacts
 - Keep the markdown header format: title, "Converted from PDF" note, source filename, then `---` separator
 - Use `<!-- Page N -->` comments to mark page boundaries

--- a/README.md
+++ b/README.md
@@ -81,16 +81,57 @@ python convert.py input/MyBook.pdf --method docling          # IBM's layout-awar
 python convert.py input/ScannedBook.pdf --method ocr         # tesseract OCR
 ```
 
-### Extract figures and images
+### Figures and images
+
+Extraction is **on by default**. Figures, diagrams, and embedded raster
+images are written to a sibling directory (`output/<stem>_assets/` for
+pymupdf, `output/<stem>_images/` for marker and pymupdf4llm), and the
+markdown carries image references to them at the right page position.
 
 ```bash
-python convert.py input/MyBook.pdf --extract-images
+python convert.py input/MyBook.pdf                      # figures kept
+python convert.py input/MyBook.pdf --no-extract-images  # text only
 ```
 
-When `--extract-images` is set, the pymupdf backend renders figures,
-diagrams, and embedded raster images as PNGs in a sibling directory
-(`output/<stem>_assets/`) and inserts markdown image references into
-the body text at the right page position.
+**The invariant: the output never contains a reference to a file that does
+not exist.** With `--no-extract-images` the references to the skipped
+figures are *stripped*, not left dangling — a text-only conversion is
+complete, never perforated. Each stripped reference leaves an HTML comment
+(`<!-- bookconvert: image omitted, asset not extracted: ... -->`) so a thin
+conversion is diagnosable rather than silent, and the sidecar records
+`dangling_refs_stripped`.
+
+This is why extraction became the default. The old default found the
+figures, emitted references to them, and then threw the files away; a
+caller had to know a flag existed to avoid producing broken output. See
+`docs/asset-invariant.md`.
+
+### The asset manifest
+
+The sidecar carries an `assets` array — one entry per file the conversion
+wrote, with the references pointing at it:
+
+```json
+"assets": [
+  {
+    "path": "MyBook_images/_page_64_Figure_7.jpeg",
+    "bytes": 48213,
+    "references": [
+      {"target": "MyBook_images/_page_64_Figure_7.jpeg", "alt": "", "line": 812}
+    ]
+  }
+]
+```
+
+`path` is relative to the markdown file. A consumer relocating a conversion
+moves each `path` and rewrites each `references[].target` where it appears
+in a `](...)` — knowing nothing about how any backend names its files.
+Do not pattern-match `_page_N_Figure_M.jpeg`: that is marker's private
+convention and it can change without notice.
+
+```bash
+jq '.assets[] | .path, (.references | length)' output/MyBook.report.json
+```
 
 ### Page locators
 
@@ -212,8 +253,9 @@ Run `marker_single --help` for the full flag list.
 ### Sidecar conversion report
 
 Every conversion writes a `<stem>.report.json` alongside the markdown
-containing: method used, page count, OCR pages, extracted assets,
-quality score, `cleaned`/`cleanup` stats, table counts, and any warnings.
+containing: method used, page count, OCR pages, extracted assets, the
+asset manifest, `dangling_refs_stripped`, quality score,
+`cleaned`/`cleanup` stats, table counts, and any warnings.
 Useful for inspecting a batch run:
 
 ```bash
@@ -335,7 +377,7 @@ behind that feature.
 - **Use `--method pymupdf4llm`** if you have Python 3.10+ and want text plus extracted images in the markdown.
 - **Use `--method marker`** if you have Python 3.10+ and want the highest-quality markdown formatting.
 - **Use `--method docling`** if you have Python 3.10+ and need IBM's layout-aware pipeline for complex layouts.
-- **Use `--extract-images`** to pull figures and diagrams out as PNGs into an `_assets/` directory alongside the markdown.
+- **Figures come out by default.** Pass `--no-extract-images` for text-only output; the references to the skipped figures are stripped so the markdown never points at a file that isn't there.
 - **Use `--auto-ocr`** to have the tool automatically retry with OCR when pymupdf fails. This catches both fully-scanned PDFs and PDFs with non-standard font encodings that produce garbled text (e.g. ligature artifacts like `n1ethod` for `method`). Without `--auto-ocr` you'll get an error message suggesting `--method ocr` and can re-run manually.
 - **OCR output may need cleanup.** Claude Code can help you fix OCR artifacts, add proper headings, and improve formatting.
 - **Inspect the sidecar report** (`output/<stem>.report.json`) after each conversion to check quality score, OCR page count, and any warnings.

--- a/assets.py
+++ b/assets.py
@@ -1,20 +1,32 @@
-"""Image region detection and rendering for BookConvert.
+"""Image region detection, rendering, and reference bookkeeping.
 
-Extracts figures, diagrams, and raster images from PDF pages and renders
-them as PNGs via clipped `page.get_pixmap`. The rendered assets get a
-markdown image reference stitched into the page text by the pymupdf
-backend.
+Two halves live here.
+
+**Detection and rendering** (pymupdf backend): extracts figures, diagrams,
+and raster images from PDF pages and renders them as PNGs via clipped
+`page.get_pixmap`. The rendered assets get a markdown image reference
+stitched into the page text by the pymupdf backend.
 
 Three sources feed the region list:
   1. Raster images embedded in the PDF (page.get_image_info()).
   2. Vector drawings clustered by bounding box (page.get_drawings()).
   3. Figure captions near the above regions (CAPTION_RE).
+
+**Reference bookkeeping** (every backend): the invariant that the emitted
+markdown never references a file that does not exist, plus the asset
+manifest that lets a consumer relocate assets without knowing how any
+backend names its files. See `enforce_reference_invariant` and
+`build_asset_manifest`. This half deliberately does not import fitz-level
+concepts — it works on markdown text and the filesystem, so every backend
+(marker, pandoc, pymupdf4llm, docling, pymupdf) can end with the same call.
 """
 from __future__ import annotations
 
 import re
+import shutil
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, Iterable, List, NamedTuple, Tuple
+from urllib.parse import unquote, urlsplit
 
 import fitz
 
@@ -228,3 +240,301 @@ def _match_caption(
             best_dist = dy
             best = text
     return best
+
+
+# ---------------------------------------------------------------------------
+# Reference bookkeeping — the never-dangle invariant and the asset manifest
+# ---------------------------------------------------------------------------
+#
+# The invariant: the markdown a conversion emits never contains a reference to
+# a file that does not exist. It was broken for a year by the marker backend,
+# which writes `_page_64_Figure_7.jpeg` files into its scratch directory and
+# emits bare `![](_page_64_Figure_7.jpeg)` references to them; BookConvert
+# harvested `*.png`/`*.jpg` (never `*.jpeg`) out of that scratch directory and
+# then deleted it, leaving every reference pointing at nothing. 1,140 dead
+# references across 49 sources downstream. See issue #34.
+#
+# Enforcement is two-layered on purpose:
+#   1. Extract by default, so the asset the reference names is actually there.
+#   2. Sweep afterwards regardless, so a reference that still has no file —
+#      because extraction was disabled, or because a backend emitted a
+#      reference to something it never wrote — is stripped, not left dangling.
+# Layer 2 is the invariant; layer 1 is what makes satisfying it not a loss.
+
+# Every raster suffix any backend of ours emits, plus the ones they might.
+IMAGE_SUFFIXES = frozenset({
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tif", ".tiff", ".svg",
+})
+
+# A markdown image reference. The inner group is everything between the
+# parentheses — target plus an optional "title" — split apart by
+# `_split_link_target` rather than by a hairier regex.
+IMAGE_REF_RE = re.compile(r'!\[(?P<alt>[^\]]*)\]\((?P<inner>[^()]*)\)')
+
+# What a stripped reference leaves behind: nothing a reader sees, and enough
+# for a human debugging a thin conversion to find out what happened.
+STRIPPED_REF_COMMENT = "<!-- bookconvert: image omitted, asset not extracted: {target} -->"
+
+# A trailing `"title"` / 'title' on a link target.
+_LINK_TITLE_RE = re.compile(r'''\s+["'][^"']*["']\s*$''')
+
+
+class ImageRef(NamedTuple):
+    """One markdown image reference located in a document."""
+
+    alt: str
+    target: str          # exactly as written between the parens
+    start: int           # character offset of the `!` in the source text
+    end: int             # character offset one past the closing paren
+    line: int            # 1-indexed line number
+
+
+def _split_link_target(inner: str) -> str:
+    """Return the target from a markdown link's parenthesised inner text."""
+    inner = inner.strip()
+    angled = re.match(r'^<(?P<t>[^>]*)>', inner)
+    if angled:
+        return angled.group("t").strip()
+    return _LINK_TITLE_RE.sub("", inner).strip()
+
+
+def is_local_target(target: str) -> bool:
+    """True if `target` names a file on disk rather than a remote resource.
+
+    Absolute paths count as local — they are still a file reference, and one
+    that points outside the output directory is exactly the kind of thing the
+    invariant should catch.
+    """
+    if not target:
+        return False
+    if target.startswith("//") or target.startswith("#"):
+        return False
+    scheme = urlsplit(target).scheme
+    # A bare Windows drive letter ("c:/x.png") parses as a scheme; a real
+    # scheme is at least two characters.
+    return len(scheme) < 2
+
+
+def iter_image_refs(text: str) -> List[ImageRef]:
+    """Every markdown image reference in `text`, in document order."""
+    refs: List[ImageRef] = []
+    for m in IMAGE_REF_RE.finditer(text):
+        target = _split_link_target(m.group("inner"))
+        refs.append(ImageRef(
+            alt=m.group("alt"),
+            target=target,
+            start=m.start(),
+            end=m.end(),
+            line=text.count("\n", 0, m.start()) + 1,
+        ))
+    return refs
+
+
+def resolve_target(md_path: Path, target: str) -> Path:
+    """Filesystem path a local reference in `md_path` points at."""
+    decoded = unquote(target)
+    path = Path(decoded)
+    if path.is_absolute():
+        return path
+    return Path(md_path).parent / path
+
+
+def collect_asset_files(root: Path) -> List[Path]:
+    """Every image file under `root`, recursively, sorted for determinism.
+
+    Suffix matching is case-insensitive and covers `.jpeg` as well as `.jpg`
+    — the one-character gap that produced issue #34.
+    """
+    root = Path(root)
+    if not root.is_dir():
+        return []
+    return sorted(
+        p for p in root.rglob("*")
+        if p.is_file() and p.suffix.lower() in IMAGE_SUFFIXES
+    )
+
+
+def harvest_assets(files: Iterable[Path], dest_dir: Path) -> Dict[str, str]:
+    """Move `files` into `dest_dir`, flattened, and map old name -> new name.
+
+    Backends drop assets in nested scratch directories under names that are
+    unique only within their own subdirectory, so flattening can collide. A
+    collision gets the parent directory name prefixed rather than silently
+    overwriting the earlier file — no asset is ever lost to a name clash.
+
+    The returned mapping is keyed by original basename, which is also how
+    references are matched, so two genuinely different files sharing a
+    basename cannot be told apart by a reference either. First one wins; both
+    files are kept. This is a real ambiguity in the input, not one this
+    function introduces, and the invariant holds regardless: the reference
+    points at a file that exists.
+    """
+    files = [Path(f) for f in files]
+    if not files:
+        return {}
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    mapping: Dict[str, str] = {}
+    taken: set = {p.name for p in dest_dir.iterdir()} if dest_dir.exists() else set()
+    for src in files:
+        name = src.name
+        if name in taken:
+            name = f"{src.parent.name}-{src.name}"
+            counter = 2
+            while name in taken:
+                name = f"{src.parent.name}-{counter}-{src.name}"
+                counter += 1
+        taken.add(name)
+        shutil.move(str(src), str(dest_dir / name))
+        mapping.setdefault(src.name, name)
+    return mapping
+
+
+def rewrite_asset_refs(text: str, mapping: Dict[str, str], dest_rel: str) -> Tuple[str, int]:
+    """Point every local reference whose basename is in `mapping` at `dest_rel`.
+
+    Matching is on the reference's *basename*, so it works whether the backend
+    emitted a bare filename (`![](_page_64_Figure_7.jpeg)`, marker) or a path
+    with directories in it (`![](images/x.png)`). Returns (text, rewrites).
+    """
+    if not mapping:
+        return text, 0
+
+    rewrites = 0
+
+    def replace(m: re.Match) -> str:
+        nonlocal rewrites
+        target = _split_link_target(m.group("inner"))
+        if not is_local_target(target):
+            return m.group(0)
+        basename = Path(unquote(target)).name
+        new_name = mapping.get(basename)
+        if new_name is None:
+            return m.group(0)
+        rewrites += 1
+        return f"![{m.group('alt')}]({dest_rel}/{new_name})"
+
+    return IMAGE_REF_RE.sub(replace, text), rewrites
+
+
+def strip_dangling_refs(text: str, md_path: Path) -> Tuple[str, List[str]]:
+    """Remove every local image reference whose file is not on disk.
+
+    Returns (text, stripped_targets). Remote references are left alone: this
+    module makes no claim about the internet. The stripped reference is
+    replaced by an HTML comment, which renders as nothing and keeps the fact
+    that something was dropped recoverable by a human.
+    """
+    stripped: List[str] = []
+
+    def replace(m: re.Match) -> str:
+        target = _split_link_target(m.group("inner"))
+        if not is_local_target(target):
+            return m.group(0)
+        if resolve_target(md_path, target).exists():
+            return m.group(0)
+        stripped.append(target)
+        return STRIPPED_REF_COMMENT.format(target=target)
+
+    return IMAGE_REF_RE.sub(replace, text), stripped
+
+
+def build_asset_manifest(md_path: Path, asset_dir=None) -> List[dict]:
+    """Describe every asset this conversion wrote, and what points at it.
+
+    `asset_dir` is a directory (or an iterable of directories) to sweep for
+    assets that exist but are referenced by nothing.
+
+    One entry per file, whether or not anything references it (an extracted
+    but unreferenced asset is information too), plus one entry per referenced
+    file that lives outside `asset_dir`. Paths are relative to the markdown
+    file, so a consumer can relocate assets and rewrite references without
+    knowing anything about how a backend names its files — which is the whole
+    point: `_page_N_Figure_M.jpeg` is marker's business, not a contract.
+
+    Entry shape:
+        {"path": "Book_images/_page_64_Figure_7.jpeg",
+         "bytes": 48213,
+         "references": [{"target": "...", "alt": "...", "line": 812}]}
+    """
+    md_path = Path(md_path)
+    if not md_path.exists():
+        return []
+    md_dir = md_path.parent
+    text = md_path.read_text(encoding="utf-8", errors="replace")
+
+    # Referenced files first, keyed by resolved path so two spellings of the
+    # same file (`x.png` and `./x.png`) land on one entry.
+    refs_by_file: Dict[Path, List[dict]] = {}
+    for ref in iter_image_refs(text):
+        if not is_local_target(ref.target):
+            continue
+        resolved = resolve_target(md_path, ref.target)
+        if not resolved.exists():
+            continue          # invariant already swept these; belt and braces
+        refs_by_file.setdefault(resolved.resolve(), []).append(
+            {"target": ref.target, "alt": ref.alt, "line": ref.line}
+        )
+
+    files: List[Path] = list(refs_by_file)
+    candidates = ([asset_dir] if isinstance(asset_dir, (str, Path))
+                  else list(asset_dir or []))
+    for candidate in candidates:
+        if not Path(candidate).is_dir():
+            continue
+        for path in collect_asset_files(candidate):
+            if path.resolve() not in refs_by_file:
+                files.append(path.resolve())
+
+    manifest: List[dict] = []
+    for path in sorted(set(files)):
+        try:
+            rel = path.relative_to(md_dir.resolve())
+            rel_str = rel.as_posix()
+        except ValueError:
+            rel_str = path.as_posix()
+        try:
+            size = path.stat().st_size
+        except OSError:
+            size = 0
+        manifest.append({
+            "path": rel_str,
+            "bytes": size,
+            "references": refs_by_file.get(path, []),
+        })
+    return manifest
+
+
+def count_dangling_refs(md_path: Path) -> int:
+    """How many local image references in `md_path` point at nothing.
+
+    The invariant says this is 0 for every conversion BookConvert emits. It
+    exists so a test — and a suspicious operator — can assert that directly.
+    """
+    md_path = Path(md_path)
+    if not md_path.exists():
+        return 0
+    text = md_path.read_text(encoding="utf-8", errors="replace")
+    return sum(
+        1 for ref in iter_image_refs(text)
+        if is_local_target(ref.target)
+        and not resolve_target(md_path, ref.target).exists()
+    )
+
+
+def enforce_reference_invariant(md_path: Path) -> List[str]:
+    """Strip every dangling local image reference from `md_path`, in place.
+
+    Returns the targets that were stripped. Writing only happens when
+    something changed, so this is a cheap no-op on the common case (a
+    text-only conversion, or one where every asset landed).
+    """
+    md_path = Path(md_path)
+    if not md_path.exists():
+        return []
+    text = md_path.read_text(encoding="utf-8", errors="replace")
+    swept, stripped = strip_dangling_refs(text, md_path)
+    if stripped:
+        md_path.write_text(swept, encoding="utf-8", errors="replace")
+    return stripped

--- a/convert.py
+++ b/convert.py
@@ -2841,12 +2841,16 @@ def _is_broken_toc_page(text):
     return matches / len(non_empty) >= 0.5
 
 
-def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
+def convert_with_pymupdf(pdf_path, output_dir, extract_images=True):
     """Convert a PDF using PyMuPDF (fitz) for text extraction.
 
     Raises ConversionError if the PDF appears to be scanned (too little text).
-    When extract_images is True, figures and diagrams are rendered as PNGs
-    into a <stem>_assets/ subdirectory alongside the markdown.
+    `extract_images` defaults to True: figures and diagrams are rendered as
+    PNGs into a <stem>_assets/ subdirectory alongside the markdown, and the
+    references in the text point at files that are there. Setting it False
+    emits neither the assets nor references to them — this backend only
+    stitches a reference in when it has just written the file, so text-only
+    output here is complete rather than perforated.
     """
     import fitz
 
@@ -3116,6 +3120,7 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=False):
     report.quality_score = quality
     report.skipped_toc_pages = skipped_toc_pages
     report.extracted_assets = total_assets
+    _finalize_assets(report, asset_dir=asset_dir)
 
     report_path = output_file.with_suffix(".report.json")
     write_report(report_path, report)
@@ -3357,13 +3362,21 @@ def warn_if_memory_is_tight(page_count=None):
     return free_gb
 
 
-def convert_with_marker(pdf_path, output_dir, marker_args=None):
+def convert_with_marker(pdf_path, output_dir, marker_args=None,
+                        extract_images=True):
     """Convert a text-based PDF using Marker.
 
     Runs Marker in an isolated temp directory to avoid corrupting existing output.
     `marker_args` is a list of extra flags forwarded verbatim to
     `marker_single` (see `marker_single --help`) — this is how table-quality
     flags like `--use_llm` and `--html_tables_in_markdown` are reached.
+
+    `extract_images` is on by default: marker finds the figures whether we ask
+    it to or not, so the only question is whether we keep them, and the
+    answer used to be no while the references stayed in the markdown. When
+    it is off we tell marker to skip image extraction outright, and the
+    finalizer strips any reference marker emits anyway.
+
     Raises ConversionError on failure.
     """
     print(f"Converting with Marker: {pdf_path.name}")
@@ -3378,6 +3391,12 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None):
         # citable address cannot be fixed later without reconverting, and
         # marker is the only backend that works on a scanned book.
         cmd.extend(MARKER_LOCATOR_ARGS)
+        if not extract_images:
+            # Only sent on the explicit opt-out path. An older marker that
+            # does not know this flag would abort the run, and that risk
+            # belongs to the caller who asked for text-only, never to the
+            # default.
+            cmd.append("--disable_image_extraction")
         if marker_args:
             cmd.extend(marker_args)
             print(f"  extra marker args: {' '.join(marker_args)}")
@@ -3416,40 +3435,14 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None):
         target = output_dir / f"{pdf_path.stem}.md"
         shutil.move(str(md_files[0]), str(target))
 
-        # Move any image directories that marker produced
-        img_dirs = [d for d in tmp_path.rglob("*") if d.is_dir() and d.name == "images"]
-        if not img_dirs:
-            # Also check for any image files directly
-            img_files = list(tmp_path.rglob("*.png")) + list(tmp_path.rglob("*.jpg"))
-            if img_files:
-                img_dest = output_dir / f"{pdf_path.stem}_images"
-                img_dest.mkdir(exist_ok=True)
-                for img in img_files:
-                    shutil.move(str(img), str(img_dest / img.name))
-                # Update image paths in the markdown
-                content = target.read_text(encoding="utf-8")
-                content = re.sub(
-                    r'!\[([^\]]*)\]\((?:[^)]*/)([^)]+)\)',
-                    rf'![\1]({pdf_path.stem}_images/\2)',
-                    content
-                )
-                target.write_text(content, encoding="utf-8")
-                print(f"  Moved {len(img_files)} image(s) to {img_dest}")
-        else:
-            for img_dir in img_dirs:
-                img_dest = output_dir / f"{pdf_path.stem}_images"
-                if img_dest.exists():
-                    shutil.rmtree(str(img_dest))
-                shutil.move(str(img_dir), str(img_dest))
-                # Update image paths in the markdown
-                content = target.read_text(encoding="utf-8")
-                content = re.sub(
-                    r'!\[([^\]]*)\]\((?:[^)]*/)([^)]+)\)',
-                    rf'![\1]({pdf_path.stem}_images/\2)',
-                    content
-                )
-                target.write_text(content, encoding="utf-8")
-                print(f"  Moved images to {img_dest}")
+        # Marker's figures live in the scratch tree beside the markdown it
+        # just wrote. `_finalize_assets` below harvests them into `img_dest`
+        # before the TemporaryDirectory takes them to the grave. A previous
+        # conversion of the same book owns nothing here, so clear the
+        # directory rather than merging two runs' assets into it.
+        img_dest = output_dir / f"{pdf_path.stem}_images"
+        if img_dest.exists():
+            shutil.rmtree(str(img_dest))
 
         if len(md_files) > 1:
             log.warning("Marker produced %d .md files; only the first was used", len(md_files))
@@ -3474,6 +3467,16 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None):
             f"{report.table_captions_seen} captions seen"
         )
         _apply_backend_page_numbering(report)
+        # Issue #34 lived in the seven lines this call replaced. They globbed
+        # `*.png` and `*.jpg` out of the scratch tree — marker writes `.jpeg`
+        # — so the files were never found and were deleted with the temp
+        # directory, while the references marker had already written into the
+        # markdown stayed put, pointing at nothing. (The rewrite regex was
+        # broken too: it required a `/` in the target, and marker's
+        # `![](_page_64_Figure_7.jpeg)` has none.) Matching is on a suffix set
+        # and on basenames now, and whatever is still unaccounted for gets
+        # stripped rather than shipped dangling.
+        _finalize_assets(report, scratch_root=tmp_path, asset_dir=img_dest)
         report_path = target.with_suffix(".report.json")
         write_report(report_path, report)
         return report
@@ -3542,6 +3545,9 @@ def convert_with_ocr(pdf_path, output_dir):
     # instead of leaving it to be discovered during a scholarly pass.
     apply_table_signals(report, output_file)
     _apply_backend_page_numbering(report)
+    # Tesseract emits plain text and never an image reference; the sweep is
+    # here so the invariant holds for every backend without exception.
+    _finalize_assets(report)
     report_path = output_file.with_suffix(".report.json")
     write_report(report_path, report)
     return report
@@ -3722,11 +3728,20 @@ def convert_with_pandoc(book_path, output_dir):
             "conversion has no structural addressing of any kind"
         )
     _apply_backend_page_numbering(report)
+    # Pandoc references the epub's internal media paths (`media/image1.jpg`)
+    # for images it never writes out, so an epub conversion dangles by
+    # construction for every reference `_clean_pandoc_output` did not already
+    # drop. Extraction is NOT the answer here the way it is for the PDF
+    # backends: the images an epub carries that survive that filter are
+    # overwhelmingly publisher furniture — covers, ornaments, imprint marks —
+    # and BookConvert's epub path is documented as text-only. So epub takes
+    # the other route to the same invariant: the references are stripped.
+    _finalize_assets(report)
     write_report(output_file.with_suffix(".report.json"), report)
     return report
 
 
-def convert_with_pymupdf4llm(pdf_path, output_dir):
+def convert_with_pymupdf4llm(pdf_path, output_dir, extract_images=True):
     """Convert a PDF using pymupdf4llm's Markdown exporter.
 
     pymupdf4llm is PyMuPDF's own LLM-oriented markdown exporter. It
@@ -3759,10 +3774,11 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
     # error out.
     safe_stem = re.sub(r"\s+", "_", pdf_path.stem)
     image_dir = output_dir / f"{safe_stem}_images"
-    image_dir.mkdir(parents=True, exist_ok=True)
+    if extract_images:
+        image_dir.mkdir(parents=True, exist_ok=True)
     page_chunks = pymupdf4llm.to_markdown(
         str(pdf_path),
-        write_images=True,
+        write_images=extract_images,
         image_path=str(image_dir),
         image_format="png",
         page_chunks=True,
@@ -3803,19 +3819,15 @@ def convert_with_pymupdf4llm(pdf_path, output_dir):
     output_file.write_text(header + markdown, encoding="utf-8", errors="replace")
     print(f"  -> {output_file}")
 
-    extracted_assets = 0
-    if image_dir.exists():
-        extracted_assets = sum(1 for _ in image_dir.glob("*"))
-
     report = ConversionReport(
         source=str(pdf_path),
         output=str(output_file),
         method="pymupdf4llm",
         total_pages=total_pages,
         pages_with_text=total_pages,  # pymupdf4llm handles its own detection
-        extracted_assets=extracted_assets,
     )
     _apply_backend_page_numbering(report)
+    _finalize_assets(report, asset_dir=image_dir)
     write_report(output_file.with_suffix(".report.json"), report)
     return report
 
@@ -3860,9 +3872,95 @@ def convert_with_docling(pdf_path, output_dir):
         pages_with_text=total_pages,
     )
     _apply_backend_page_numbering(report)
+    # Docling's default export mode emits `<!-- image -->` placeholders rather
+    # than file references, so there is normally nothing here to enforce. It
+    # gets the same sweep anyway: the invariant is a property of BookConvert's
+    # output, not a favour we do the backends we happen to distrust.
+    _finalize_assets(report)
     write_report(output_file.with_suffix(".report.json"), report)
     return report
 
+
+
+def _finalize_assets(report, scratch_root=None, asset_dir=None):
+    """Land every asset, kill every dead reference, and record the manifest.
+
+    The last thing each backend does. Three steps, in order:
+
+    1. **Harvest.** If the backend wrote its assets into a scratch directory
+       it is about to lose (marker's temp tree), move them next to the
+       markdown and repoint the references at their new home. Backends that
+       write straight into the output directory pass `asset_dir` alone.
+    2. **Enforce.** Strip any reference still pointing at a file that does not
+       exist. This is the invariant — *the output never contains a reference
+       to a file that does not exist* — and it holds no matter which backend
+       ran, whether extraction was on, or what the backend believed it wrote.
+       Extraction-by-default (step 1 and the `--extract-images` default) is
+       what keeps satisfying the invariant from being a loss; this step is
+       what makes it true.
+    3. **Manifest.** Record every asset and the references pointing at it, so
+       a consumer can relocate assets without pattern-matching a backend's
+       private filename convention.
+
+    See issue #34: marker emitted `![](_page_64_Figure_7.jpeg)` while writing
+    no such file, 1,140 times across 49 sources, and nothing in the output
+    said so.
+    """
+    if not isinstance(report, ConversionReport) or not report.output:
+        return report
+    md_path = Path(report.output)
+    if not md_path.exists():
+        return report
+    asset_dir = Path(asset_dir) if asset_dir is not None else None
+
+    if scratch_root is not None:
+        harvested = assets.collect_asset_files(scratch_root)
+        if harvested:
+            if asset_dir is None:
+                asset_dir = md_path.parent / f"{md_path.stem}_images"
+            mapping = assets.harvest_assets(harvested, asset_dir)
+            text = md_path.read_text(encoding="utf-8", errors="replace")
+            text, rewrites = assets.rewrite_asset_refs(
+                text, mapping, asset_dir.name
+            )
+            md_path.write_text(text, encoding="utf-8", errors="replace")
+            print(
+                f"  assets: {len(mapping)} written to {asset_dir.name}/ "
+                f"({rewrites} reference(s) repointed)"
+            )
+
+    stripped = assets.enforce_reference_invariant(md_path)
+    report.assets = assets.build_asset_manifest(md_path, asset_dir)
+    report.extracted_assets = len(report.assets)
+    report.dangling_refs_stripped = len(stripped)
+    if stripped:
+        report.warnings.append(
+            f"stripped {len(stripped)} image reference(s) to files that were "
+            f"not written (first: {stripped[0]}). The output is intact; the "
+            f"figures are not in it."
+        )
+        print(
+            f"  WARNING: {len(stripped)} image reference(s) pointed at files "
+            f"that were never written; stripped so the output does not dangle."
+        )
+    return report
+
+
+def _refresh_asset_manifest(report):
+    """Rebuild the manifest against the markdown as it now stands on disk.
+
+    Used after a pass that rewrites the file (cleanup), because the manifest
+    carries per-reference line numbers. Asset directories are recovered from
+    the existing manifest so assets nothing references stay listed.
+    """
+    md_path = Path(report.output)
+    asset_dirs = {
+        md_path.parent / Path(entry["path"]).parent
+        for entry in report.assets
+        if Path(entry["path"]).parent != Path(".")
+    }
+    report.assets = assets.build_asset_manifest(md_path, asset_dirs)
+    report.extracted_assets = len(report.assets)
 
 
 def _apply_cleanup(result):
@@ -3892,6 +3990,10 @@ def _apply_cleanup(result):
     # file that actually landed on disk.
     if cleaned != original:
         result.tables_emitted, result.table_captions_seen = count_table_signals(cleaned)
+        # The manifest records a line number per reference. Cleanup rewrites
+        # the file underneath it, so recompute rather than ship a manifest
+        # that describes the pre-cleanup text.
+        _refresh_asset_manifest(result)
     if not stats.get("dejoin_available"):
         result.warnings.append(
             "cleanup: de-join pass skipped (pyspellchecker not installed; "
@@ -3993,14 +4095,17 @@ def describe_other_conversions(others, now):
 
 
 def convert_book(book_path, output_dir, method="pymupdf", auto_ocr=False,
-                 extract_images=False, clean=True, marker_args=None):
+                 extract_images=True, clean=True, marker_args=None):
     """Convert a single book (PDF or EPUB) to markdown.
 
     Returns True on success, False on failure. Never raises.
     EPUB files route through pandoc regardless of `method`. For PDFs,
     if auto_ocr is True and pymupdf/marker fails due to scanned content,
     automatically retries with OCR.
-    When extract_images is True, figures are rendered as PNGs (pymupdf only).
+    `extract_images` defaults to True: every PDF backend writes the figures
+    it finds. Setting it False converts text only and strips the references
+    to the figures that were skipped, so the output never dangles either way
+    (issue #34).
     When clean is True (default), a verbatim-safe post-conversion pass repairs
     common extraction artifacts (dropped-space joins, stray-consonant citation
     ghosts, picture-text garble) on the emitted markdown.
@@ -4029,9 +4134,12 @@ def convert_book(book_path, output_dir, method="pymupdf", auto_ocr=False,
         if method == "ocr":
             result = convert_with_ocr(book_path, output_dir)
         elif method == "marker":
-            result = convert_with_marker(book_path, output_dir, marker_args=marker_args)
+            result = convert_with_marker(book_path, output_dir,
+                                         marker_args=marker_args,
+                                         extract_images=extract_images)
         elif method == "pymupdf4llm":
-            result = convert_with_pymupdf4llm(book_path, output_dir)
+            result = convert_with_pymupdf4llm(book_path, output_dir,
+                                              extract_images=extract_images)
         elif method == "docling":
             result = convert_with_docling(book_path, output_dir)
         else:
@@ -4055,7 +4163,9 @@ def convert_book(book_path, output_dir, method="pymupdf", auto_ocr=False,
             try:
                 check_dependencies(chosen)
                 if chosen == "marker":
-                    result = convert_with_marker(book_path, output_dir, marker_args=marker_args)
+                    result = convert_with_marker(book_path, output_dir,
+                                                 marker_args=marker_args,
+                                                 extract_images=extract_images)
                 else:
                     result = convert_with_ocr(book_path, output_dir)
                 if clean:
@@ -4214,9 +4324,14 @@ def main():
     )
     parser.add_argument(
         "--extract-images",
-        action="store_true",
-        help="Extract figures, diagrams, and raster images as PNGs alongside "
-             "the markdown (pymupdf backend only).",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Write figures, diagrams, and raster images alongside the "
+             "markdown. ON by default: a backend that emits a reference to a "
+             "figure has already done the work of finding it, and throwing "
+             "the file away is pure loss. --no-extract-images converts text "
+             "only — the references to the discarded figures are stripped, "
+             "never left dangling.",
     )
     parser.add_argument(
         "--marker-args",

--- a/docs/asset-invariant.md
+++ b/docs/asset-invariant.md
@@ -1,0 +1,143 @@
+# The asset invariant
+
+> **The output never contains a reference to a file that does not exist.**
+
+Closes [issue #34](https://github.com/AndySparks/BookConvert/issues/34).
+
+## What went wrong
+
+A conversion could emit `![](_page_64_Figure_7.jpeg)` into the markdown while
+writing no such file. Measured in the consuming vault on 2026-07-28:
+
+| | |
+|---|---|
+| Sources carrying local figure references | 53 |
+| Of those, sources with **dangling** references | **49** |
+| Total dangling references | **1,140** |
+
+~92% of every converted source that should show a figure showed none — with
+`quality_score: 1.0` and `extracted_assets: 0` in the sidecar, reporting the
+truth to nobody.
+
+## The mechanism
+
+Two bugs in the marker backend's asset harvesting, either of which alone was
+enough:
+
+1. **The suffix.** Marker writes its figures as `.jpeg`. The harvesting code
+   globbed `rglob("*.png")` and `rglob("*.jpg")` out of marker's scratch
+   directory. `fnmatch("_page_64_Figure_7.jpeg", "*.jpg")` is `False`, so the
+   files were never found — and the scratch directory was a
+   `TemporaryDirectory`, so they were deleted moments later.
+2. **The slash.** The reference-rewriting regex was
+   `!\[([^\]]*)\]\((?:[^)]*/)([^)]+)\)` — the `(?:[^)]*/)` group is not
+   optional, so it only matches a target containing a directory separator.
+   Marker's references are bare filenames. Even on the path where the files
+   *were* found, the references would not have been repointed.
+
+Both are the kind of bug that a test asserting "images get moved" passes over,
+because the code path is only reached when the glob matches. What catches them
+is asserting the *property* — zero dangling references in the emitted markdown
+— which is what `tests/test_asset_invariant.py` does.
+
+## Why extraction is now the default
+
+The issue proposed two routes. Both are implemented, at different layers.
+
+**Route 1 — extraction becomes the default (`--extract-images` defaults on).**
+This is the primary fix. The decisive fact is that the figures are already
+extracted internally: marker finds them whether or not we ask, and pymupdf's
+detector runs against pages we have already opened. The old default paid the
+full cost of finding a figure and then threw the file away, which is pure
+loss. `--no-extract-images` is the opt-out for a caller who genuinely wants
+text only.
+
+The deeper reason is the one the issue names: *the instinct is to document the
+flag harder, and that is treating the symptom*. The consuming runbook never
+mentioned `--extract-images` — not once — so every ingest that followed the
+documented process produced broken output. A default that requires knowing a
+flag exists in order to avoid producing broken output is a bad default, and no
+amount of documentation fixes it.
+
+**Route 2 — refuse to emit a reference to an asset we did not write.** This is
+the backstop, and it runs unconditionally on every backend at the end of every
+conversion (`convert._finalize_assets` → `assets.enforce_reference_invariant`).
+Route 1 makes the invariant cheap to satisfy; route 2 is what makes it *true*
+— including when extraction is disabled, when a backend loses its assets, and
+when a future backend emits a reference to something it never wrote.
+
+A stripped reference leaves an HTML comment:
+
+```markdown
+<!-- bookconvert: image omitted, asset not extracted: _page_64_Figure_7.jpeg -->
+```
+
+It renders as nothing, and it means a thin conversion is diagnosable by a human
+reading the file rather than silent. The sidecar counts them in
+`dangling_refs_stripped`, and a non-zero count adds a warning.
+
+## Backend coverage
+
+| Backend | Emits references? | Route |
+|---|---|---|
+| **marker** | Yes — bare `_page_N_Figure_M.jpeg`. **This is the one that broke.** | Assets harvested by suffix set (not two globs) and references repointed by basename (not by a regex needing a `/`). `--no-extract-images` forwards `--disable_image_extraction` to `marker_single`. |
+| **pymupdf** | Only when it has just written the file | Extraction default flipped on. Structurally cannot dangle: the reference is stitched in by the same code that saves the PNG. |
+| **pymupdf4llm** | Yes, into `<stem>_images/` | `write_images` now follows `extract_images` instead of being hardcoded on. Its path-prefix rewrite was already correct; the sweep covers what it misses. |
+| **docling** | No — its default export mode emits `<!-- image -->` placeholders | Swept anyway. The invariant is a property of BookConvert's output, not a favour done to the backends we happen to distrust. |
+| **ocr** (tesseract) | No — plain text only | Swept anyway. |
+| **pandoc** (EPUB) | **Yes** — the epub's internal media paths, for images it never writes | Route 2 only, deliberately. Extraction is not the answer here: the images an epub carries that survive `_clean_pandoc_output`'s decorative-glyph filter are overwhelmingly publisher furniture (covers, ornaments, imprint marks), and the epub path is documented as text-only. The references are stripped. |
+
+So marker is the backend that motivated the issue, but it was not the only one
+that could dangle — pandoc dangles by construction on any epub whose image
+references carry alt text.
+
+## The asset manifest
+
+The second half of the issue. Consumers were relocating assets by
+pattern-matching `_page_N_Figure_M.jpeg` — marker's internal naming convention,
+an implementation detail crossing a module boundary. A rename inside marker
+silently breaks every downstream filer.
+
+The sidecar now carries an explicit manifest:
+
+```json
+"assets": [
+  {
+    "path": "MyBook_images/_page_64_Figure_7.jpeg",
+    "bytes": 48213,
+    "references": [
+      {"target": "MyBook_images/_page_64_Figure_7.jpeg", "alt": "", "line": 812}
+    ]
+  }
+],
+"extracted_assets": 1,
+"dangling_refs_stripped": 0
+```
+
+- **`path`** — the asset, relative to the markdown file. Move this.
+- **`bytes`** — size on disk, for a consumer that wants to skip 200-byte
+  ornaments.
+- **`references`** — every place in the markdown that points at this asset.
+  `target` is the link target *exactly as written*, so rewriting is a
+  substitution of `](target)`; `line` is 1-indexed and accurate against the
+  file as shipped (the manifest is recomputed after the cleanup pass, which
+  rewrites the markdown underneath it). `alt` is the alt text.
+
+An asset that nothing references still gets an entry with `references: []` —
+that is information, being the signature of a reference lost upstream.
+
+The full round trip is exercised by
+`test_manifest_round_trip_relocates_every_asset`: a consumer relocates every
+asset and rewrites every reference without looking at a filename, a suffix, or
+a page-number pattern.
+
+## Verifying the invariant
+
+```python
+import assets
+assets.count_dangling_refs("output/MyBook.md")   # 0, always
+```
+
+```bash
+jq '.dangling_refs_stripped, (.assets | length)' output/*.report.json
+```

--- a/report.py
+++ b/report.py
@@ -26,6 +26,22 @@ class ConversionReport:
     ocr_pages: int = 0
     two_column_pages: int = 0
     extracted_assets: int = 0
+    # Asset manifest. `assets` is one entry per file this conversion wrote,
+    # with the references that point at it:
+    #   {"path": "Book_images/_page_64_Figure_7.jpeg",
+    #    "bytes": 48213,
+    #    "references": [{"target": "...", "alt": "...", "line": 812}]}
+    # Paths are relative to the markdown file. A consumer relocates assets by
+    # reading this list — never by pattern-matching a backend's filename
+    # convention, which is a private detail that changes without notice.
+    #
+    # `dangling_refs_stripped` counts references to files that were not
+    # written and so were removed from the markdown. The invariant is that
+    # the emitted markdown has zero remaining dangling references; a non-zero
+    # count here says how much the sweep had to do to get there, which is the
+    # signal that extraction was off or a backend lost its assets (issue #34).
+    assets: List[dict] = field(default_factory=list)
+    dangling_refs_stripped: int = 0
     quality_score: float = 1.0
     skipped_toc_pages: int = 0
     cleaned: bool = False

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -540,3 +540,130 @@ def build_structureless_epub(
          '    <p>Nor here. The nav is empty too.</p>' % cls),
     ]
     return build_epub(tmp_path, docs, nav=None, nav_style="none", name=name)
+
+
+# --- marker stand-in -------------------------------------------------------
+#
+# A real marker run on a book is 25+ minutes and needs model weights. What the
+# asset invariant depends on is not marker's cleverness but its *output shape*:
+# a markdown file that references figures by bare `.jpeg` filename, and the
+# figure files sitting beside it in marker's own scratch directory. That shape
+# is what these fixtures reproduce.
+
+MARKER_FIGURE_PAGE = """\
+{{{page}}}------------------------------------------------
+
+## Chapter {page}
+
+The model below is the one the rest of the chapter argues from.
+
+![]({figure})
+
+*Figure {page}.1 The four-quadrant model.*
+
+Managers who skip it tend to skip the argument with it.
+"""
+
+
+def fake_marker_output(out_dir: Path, stem: str, pages=(3, 7),
+                       write_images: bool = True,
+                       suffix: str = ".jpeg") -> Path:
+    """Write a directory shaped like a real marker_single run.
+
+    marker writes `<out_dir>/<stem>/<stem>.md` plus its figure files as
+    siblings of that markdown, named `_page_N_Figure_M.jpeg`. The references
+    in the markdown are bare filenames with no directory component — which is
+    why a rewrite regex that requires a `/` never matched them.
+
+    With `write_images=False` the references are emitted and the files are
+    not, which is precisely the state issue #34 describes.
+    """
+    doc_dir = Path(out_dir) / stem
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    body = []
+    for page in pages:
+        figure = f"_page_{page}_Figure_1{suffix}"
+        body.append(MARKER_FIGURE_PAGE.format(page=page, figure=figure))
+        if write_images:
+            # A one-pixel PNG is a real file with real bytes; the suffix is
+            # what the harvesting code keys on, and lying about it is the
+            # point of the test.
+            (doc_dir / figure).write_bytes(_ONE_PIXEL_PNG)
+    md = doc_dir / f"{stem}.md"
+    md.write_text("\n".join(body), encoding="utf-8")
+    return md
+
+
+# Smallest valid PNG: 1x1, opaque white.
+_ONE_PIXEL_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d494844520000000100000001080200000090"
+    "7753de0000000c4944415408d763f8cfc0000003010100189dd6e1000000"
+    "0049454e44ae426082"
+)
+
+
+def patch_marker(monkeypatch, convert_module, **kwargs):
+    """Make `convert_with_marker` run against `fake_marker_output`.
+
+    Stubs the subprocess.Popen call so no marker, no model weights, and no
+    25-minute wait are involved. Extra kwargs are forwarded to
+    `fake_marker_output`; `--disable_image_extraction` on the command line
+    overrides `write_images`, the way real marker would.
+    """
+    def fake_popen(cmd, *args, **popen_kwargs):
+        out_dir = Path(cmd[cmd.index("--output_dir") + 1])
+        stem = Path(cmd[1]).stem
+        opts = dict(kwargs)
+        if "--disable_image_extraction" in cmd:
+            opts["write_images"] = False
+            opts["emit_refs"] = opts.get("emit_refs", False)
+        if opts.pop("emit_refs", True):
+            fake_marker_output(out_dir, stem, **opts)
+        else:
+            # marker with image extraction disabled drops the references too.
+            doc_dir = out_dir / stem
+            doc_dir.mkdir(parents=True, exist_ok=True)
+            (doc_dir / f"{stem}.md").write_text(
+                "{3}------------------------------------------------\n\n"
+                "## Chapter 3\n\nText only.\n",
+                encoding="utf-8",
+            )
+        return _FakeProc()
+
+    monkeypatch.setattr(convert_module.subprocess, "Popen", fake_popen)
+
+
+class _FakeProc:
+    """Just enough of Popen for convert_with_marker's streaming loop."""
+
+    def __init__(self, lines=("Loaded detection model\n", "Saved output\n")):
+        self.stdout = iter(lines)
+
+    def wait(self):
+        return 0
+
+
+def build_figure_epub(tmp_path: Path, name: str = "figure.epub") -> Path:
+    """An EPUB whose chapters carry `<img>` tags with alt text.
+
+    Pandoc turns these into markdown image references pointing at the epub's
+    internal media paths — for images BookConvert never writes out. Alt text
+    matters: `_clean_pandoc_output` already drops empty-alt references on
+    their own line, so an alt-bearing image is the one that survives to
+    dangle. This is the epub half of issue #34.
+    """
+    docs = [
+        ("ch1.xhtml",
+         '    <h1>The Opening Move</h1>\n'
+         '    <p>She names the work before anyone touches it.</p>\n'
+         '    <p><img src="images/fig1.png" alt="Figure 1.1 The loop"/></p>'),
+        ("ch2.xhtml",
+         '    <h1>The Second Move</h1>\n'
+         '    <p>Then she tells them, in words they can repeat.</p>\n'
+         '    <p><img src="images/fig2.png" alt="Figure 2.1 The ladder"/></p>'),
+    ]
+    nav = [
+        (1, "The Opening Move", "ch1.xhtml"),
+        (1, "The Second Move", "ch2.xhtml"),
+    ]
+    return build_epub(tmp_path, docs, nav, "ncx", name=name)

--- a/tests/test_asset_invariant.py
+++ b/tests/test_asset_invariant.py
@@ -1,0 +1,427 @@
+"""The never-dangle asset invariant (issue #34).
+
+*The output never contains a reference to a file that does not exist.*
+
+It was broken for a year in the place it mattered most. Marker writes its
+figures as `_page_64_Figure_7.jpeg` beside the markdown in its scratch
+directory; BookConvert harvested `*.png` and `*.jpg` out of that directory —
+never `*.jpeg` — and then deleted it, leaving every reference marker had
+already written pointing at nothing. 1,140 dead references across 49 sources
+downstream; ~92% of every converted source that should show a figure showed
+none, with `quality_score: 1.0` on all of them.
+
+These tests hold the invariant from both directions: the figures are written
+by default, and when they are not written the references go with them. No
+real marker run is involved — `fixtures.patch_marker` reproduces marker's
+output *shape*, which is the only part of marker this behaviour depends on.
+"""
+import json
+import shutil
+
+import pytest
+
+import assets
+import convert
+from tests import fixtures
+
+pandoc_only = pytest.mark.skipif(
+    shutil.which("pandoc") is None, reason="pandoc not installed"
+)
+
+
+def sidecar(md_path):
+    return json.loads(
+        md_path.with_suffix(".report.json").read_text(encoding="utf-8")
+    )
+
+
+# --- reference parsing -----------------------------------------------------
+
+
+def test_iter_image_refs_finds_bare_and_pathed_targets():
+    refs = assets.iter_image_refs(
+        "intro\n\n![](_page_64_Figure_7.jpeg)\n\n![A cap](images/x.png)\n"
+    )
+    assert [r.target for r in refs] == ["_page_64_Figure_7.jpeg", "images/x.png"]
+    assert [r.alt for r in refs] == ["", "A cap"]
+    assert [r.line for r in refs] == [3, 5]
+
+
+def test_iter_image_refs_handles_titles_and_angle_brackets():
+    refs = assets.iter_image_refs('![a](x.png "A title")\n![b](<y z.png>)')
+    assert [r.target for r in refs] == ["x.png", "y z.png"]
+
+
+def test_remote_targets_are_not_local():
+    assert not assets.is_local_target("https://example.com/x.png")
+    assert not assets.is_local_target("data:image/png;base64,AAAA")
+    assert not assets.is_local_target("//cdn.example.com/x.png")
+    assert assets.is_local_target("_page_64_Figure_7.jpeg")
+    assert assets.is_local_target("Book_images/x.png")
+
+
+def test_strip_leaves_remote_references_alone(tmp_path):
+    md = tmp_path / "doc.md"
+    md.write_text("![](https://example.com/x.png)\n![](missing.png)\n")
+    text, stripped = assets.strip_dangling_refs(md.read_text(), md)
+    assert stripped == ["missing.png"]
+    assert "https://example.com/x.png" in text
+    assert "![](missing.png)" not in text
+
+
+def test_strip_leaves_references_whose_file_exists(tmp_path):
+    (tmp_path / "there.png").write_bytes(fixtures._ONE_PIXEL_PNG)
+    md = tmp_path / "doc.md"
+    md.write_text("![](there.png)\n![](gone.png)\n")
+    text, stripped = assets.strip_dangling_refs(md.read_text(), md)
+    # Selectivity: the sweep fired once, on exactly the one bad reference.
+    assert stripped == ["gone.png"]
+    assert "![](there.png)" in text
+
+
+def test_rewrite_matches_on_basename_not_on_a_slash():
+    """The old rewrite regex required a `/` in the target. Marker's bare
+    `![](_page_64_Figure_7.jpeg)` has none, so it was never rewritten even
+    on the path where the files had been found."""
+    text, n = assets.rewrite_asset_refs(
+        "![](_page_64_Figure_7.jpeg) and ![](sub/dir/other.png)",
+        {"_page_64_Figure_7.jpeg": "_page_64_Figure_7.jpeg",
+         "other.png": "other.png"},
+        "Book_images",
+    )
+    assert n == 2
+    assert "](Book_images/_page_64_Figure_7.jpeg)" in text
+    assert "](Book_images/other.png)" in text
+
+
+def test_harvest_collects_jpeg_not_just_jpg(tmp_path):
+    """The one-character gap that caused issue #34."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    for name in ("a.jpeg", "b.JPG", "c.png", "d.md", "e.txt"):
+        (scratch / name).write_bytes(b"x")
+    found = {p.name for p in assets.collect_asset_files(scratch)}
+    assert found == {"a.jpeg", "b.JPG", "c.png"}
+
+
+def test_harvest_does_not_overwrite_on_a_name_collision(tmp_path):
+    scratch = tmp_path / "scratch"
+    (scratch / "one").mkdir(parents=True)
+    (scratch / "two").mkdir()
+    (scratch / "one" / "img.png").write_bytes(b"first")
+    (scratch / "two" / "img.png").write_bytes(b"second")
+    dest = tmp_path / "out_images"
+    mapping = assets.harvest_assets(
+        assets.collect_asset_files(scratch), dest
+    )
+    # Both files survived, under distinct names. Neither was overwritten.
+    assert len(list(dest.iterdir())) == 2
+    assert {p.read_bytes() for p in dest.iterdir()} == {b"first", b"second"}
+    # References are matched by basename, so a shared basename is ambiguous
+    # by construction: first one wins, and it points at a file that exists.
+    assert mapping == {"img.png": "img.png"}
+    assert (dest / "img.png").exists()
+
+
+# --- marker: the backend that broke the invariant --------------------------
+
+
+def test_marker_with_no_flags_writes_the_figures_it_references(tmp_path, monkeypatch):
+    pdf = fixtures.build_text_pdf(tmp_path, pages=2)
+    out = tmp_path / "out"
+    out.mkdir()
+    fixtures.patch_marker(monkeypatch, convert)
+
+    report = convert.convert_with_marker(pdf, out)
+    md = out / f"{pdf.stem}.md"
+
+    # The acceptance bar: zero dangling references.
+    assert assets.count_dangling_refs(md) == 0
+
+    # And the figures are actually there, not merely un-referenced.
+    asset_dir = out / f"{pdf.stem}_images"
+    assert sorted(p.name for p in asset_dir.iterdir()) == [
+        "_page_3_Figure_1.jpeg", "_page_7_Figure_1.jpeg"
+    ]
+    assert report.extracted_assets == 2
+    assert report.dangling_refs_stripped == 0
+
+    # References were repointed into the asset directory.
+    text = md.read_text(encoding="utf-8")
+    assert f"]({pdf.stem}_images/_page_3_Figure_1.jpeg)" in text
+    assert "](_page_3_Figure_1.jpeg)" not in text
+
+
+def test_marker_that_loses_its_assets_does_not_dangle(tmp_path, monkeypatch):
+    """The exact issue #34 shape: references emitted, files never written."""
+    pdf = fixtures.build_text_pdf(tmp_path, pages=2)
+    out = tmp_path / "out"
+    out.mkdir()
+    fixtures.patch_marker(monkeypatch, convert, write_images=False)
+
+    report = convert.convert_with_marker(pdf, out)
+    md = out / f"{pdf.stem}.md"
+
+    assert assets.count_dangling_refs(md) == 0
+    assert report.dangling_refs_stripped == 2
+    assert report.assets == []
+    # The sidecar says so out loud, rather than reporting quality 1.0 in
+    # silence the way it did for a year.
+    assert any("stripped 2 image reference" in w for w in report.warnings)
+    # No image reference survives. The filename does, inside an HTML comment
+    # that renders as nothing — a dropped figure should be recoverable by a
+    # human reading the file, not silent.
+    text = md.read_text(encoding="utf-8")
+    assert assets.iter_image_refs(text) == []
+    assert text.count("bookconvert: image omitted") == 2
+
+
+def test_marker_with_extraction_disabled_does_not_dangle(tmp_path, monkeypatch):
+    """Route 2 explicitly: extraction off, and still zero dangling refs."""
+    pdf = fixtures.build_text_pdf(tmp_path, pages=2)
+    out = tmp_path / "out"
+    out.mkdir()
+    # A marker that emits references anyway despite being told not to
+    # extract. Real marker drops them; we do not depend on that.
+    fixtures.patch_marker(monkeypatch, convert, emit_refs=True)
+
+    report = convert.convert_with_marker(pdf, out, extract_images=False)
+    md = out / f"{pdf.stem}.md"
+
+    assert assets.count_dangling_refs(md) == 0
+    assert report.dangling_refs_stripped == 2
+    assert not (out / f"{pdf.stem}_images").exists()
+    # The surrounding prose is untouched; only the reference goes.
+    assert "the one the rest of the chapter argues from" in md.read_text()
+
+
+def test_reconverting_does_not_accumulate_stale_assets(tmp_path, monkeypatch):
+    """The asset directory belongs to the current run, not to its ancestors."""
+    pdf = fixtures.build_text_pdf(tmp_path, pages=2)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    fixtures.patch_marker(monkeypatch, convert, pages=(3, 7))
+    convert.convert_with_marker(pdf, out)
+    fixtures.patch_marker(monkeypatch, convert, pages=(4,))
+    report = convert.convert_with_marker(pdf, out)
+
+    asset_dir = out / f"{pdf.stem}_images"
+    assert [p.name for p in asset_dir.iterdir()] == ["_page_4_Figure_1.jpeg"]
+    assert len(report.assets) == 1
+    assert assets.count_dangling_refs(out / f"{pdf.stem}.md") == 0
+
+
+def test_extraction_disabled_is_passed_through_to_marker(tmp_path, monkeypatch):
+    pdf = fixtures.build_text_pdf(tmp_path, pages=1)
+    out = tmp_path / "out"
+    out.mkdir()
+    seen = {}
+
+    real_patch = fixtures.patch_marker
+
+    def capture(monkeypatch_, module, **kw):
+        real_patch(monkeypatch_, module, **kw)
+        inner = module.subprocess.Popen
+
+        def wrapper(cmd, *a, **k):
+            seen["cmd"] = list(cmd)
+            return inner(cmd, *a, **k)
+
+        monkeypatch_.setattr(module.subprocess, "Popen", wrapper)
+
+    capture(monkeypatch, convert)
+    convert.convert_with_marker(pdf, out, extract_images=False)
+    assert "--disable_image_extraction" in seen["cmd"]
+
+    capture(monkeypatch, convert)
+    convert.convert_with_marker(pdf, out)
+    assert "--disable_image_extraction" not in seen["cmd"]
+
+
+# --- pymupdf ---------------------------------------------------------------
+
+
+def test_pymupdf_extracts_figures_by_default(tmp_path):
+    pdf = fixtures.build_figure_pdf(tmp_path)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    report = convert.convert_with_pymupdf(pdf, out)
+    md = out / f"{pdf.stem}.md"
+
+    assert assets.count_dangling_refs(md) == 0
+    assert report.extracted_assets >= 1
+    assert (out / f"{pdf.stem}_assets").is_dir()
+    assert report.dangling_refs_stripped == 0
+
+
+def test_pymupdf_with_extraction_disabled_emits_no_references(tmp_path):
+    pdf = fixtures.build_figure_pdf(tmp_path)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    report = convert.convert_with_pymupdf(pdf, out, extract_images=False)
+    md = out / f"{pdf.stem}.md"
+
+    assert assets.count_dangling_refs(md) == 0
+    assert not (out / f"{pdf.stem}_assets").exists()
+    assert report.assets == []
+
+
+# --- the population the invariant must not touch ---------------------------
+
+
+def test_text_only_conversion_is_unaffected(tmp_path):
+    pdf = fixtures.build_text_pdf(tmp_path, pages=3)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    report = convert.convert_with_pymupdf(pdf, out)
+    md = out / f"{pdf.stem}.md"
+    text = md.read_text(encoding="utf-8")
+
+    assert "Lorem ipsum dolor sit amet." in text
+    assert "bookconvert: image omitted" not in text
+    assert report.assets == []
+    assert report.dangling_refs_stripped == 0
+    assert report.extracted_assets == 0
+    assert sidecar(md)["assets"] == []
+
+
+@pandoc_only
+def test_epub_with_figures_has_no_dangling_references(tmp_path):
+    """Pandoc references the epub's internal media for images it never
+    writes, so an epub dangles by construction. The epub path takes route 2
+    to the invariant: the references are stripped, not extracted."""
+    epub = fixtures.build_figure_epub(tmp_path)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    report = convert.convert_with_pandoc(epub, out)
+    md = out / f"{epub.stem}.md"
+
+    assert assets.count_dangling_refs(md) == 0
+    assert report.dangling_refs_stripped == 2
+    # The prose around them is untouched.
+    text = md.read_text(encoding="utf-8")
+    assert "She names the work before anyone touches it." in text
+    assert "in words they can repeat." in text
+
+
+@pandoc_only
+def test_epub_without_figures_is_unaffected(tmp_path):
+    epub = fixtures.build_semantic_epub(tmp_path)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    report = convert.convert_with_pandoc(epub, out)
+    md = out / f"{epub.stem}.md"
+
+    assert assets.count_dangling_refs(md) == 0
+    assert report.dangling_refs_stripped == 0
+    assert "bookconvert: image omitted" not in md.read_text(encoding="utf-8")
+
+
+# --- the manifest ----------------------------------------------------------
+
+
+def test_manifest_shape(tmp_path, monkeypatch):
+    pdf = fixtures.build_text_pdf(tmp_path, pages=2)
+    out = tmp_path / "out"
+    out.mkdir()
+    fixtures.patch_marker(monkeypatch, convert)
+
+    convert.convert_with_marker(pdf, out)
+    data = sidecar(out / f"{pdf.stem}.md")
+
+    assert len(data["assets"]) == 2
+    entry = data["assets"][0]
+    assert set(entry) == {"path", "bytes", "references"}
+    assert entry["path"] == f"{pdf.stem}_images/_page_3_Figure_1.jpeg"
+    assert entry["bytes"] > 0
+    assert len(entry["references"]) == 1
+    ref = entry["references"][0]
+    assert set(ref) == {"target", "alt", "line"}
+    assert ref["target"] == entry["path"]
+    # The count the issue asked for: assets vs references, checkable.
+    assert data["extracted_assets"] == len(data["assets"]) == 2
+    assert data["dangling_refs_stripped"] == 0
+
+
+def test_manifest_records_an_asset_nothing_references(tmp_path, monkeypatch):
+    pdf = fixtures.build_text_pdf(tmp_path, pages=2)
+    out = tmp_path / "out"
+    out.mkdir()
+    fixtures.patch_marker(monkeypatch, convert)
+    convert.convert_with_marker(pdf, out)
+
+    # An extracted-but-orphaned asset is information, not noise: it is the
+    # signature of a reference that went missing somewhere upstream.
+    asset_dir = out / f"{pdf.stem}_images"
+    (asset_dir / "orphan.png").write_bytes(fixtures._ONE_PIXEL_PNG)
+    report = convert.ConversionReport(
+        source=str(pdf), output=str(out / f"{pdf.stem}.md"), method="marker"
+    )
+    convert._finalize_assets(report, asset_dir=asset_dir)
+
+    orphan = [a for a in report.assets if a["path"].endswith("orphan.png")]
+    assert len(orphan) == 1
+    assert orphan[0]["references"] == []
+
+
+def test_manifest_round_trip_relocates_every_asset(tmp_path, monkeypatch):
+    """A consumer files the conversion elsewhere using ONLY the manifest.
+
+    Nothing below looks at a filename, a suffix, or a `_page_N_Figure_M`
+    pattern — which is the point. Marker can rename its output tomorrow and
+    this consumer keeps working.
+    """
+    pdf = fixtures.build_text_pdf(tmp_path, pages=2)
+    out = tmp_path / "out"
+    out.mkdir()
+    fixtures.patch_marker(monkeypatch, convert)
+    convert.convert_with_marker(pdf, out)
+
+    md = out / f"{pdf.stem}.md"
+    manifest = sidecar(md)["assets"]
+    assert manifest
+
+    # --- the consumer ---
+    vault = tmp_path / "vault"
+    (vault / "attachments").mkdir(parents=True)
+    text = md.read_text(encoding="utf-8")
+    for i, entry in enumerate(manifest):
+        src = md.parent / entry["path"]
+        new_name = f"source-figure-{i + 1}{src.suffix}"
+        shutil.copy(src, vault / "attachments" / new_name)
+        for ref in entry["references"]:
+            text = text.replace(
+                f"]({ref['target']})", f"](attachments/{new_name})"
+            )
+    filed = vault / "source.md"
+    filed.write_text(text, encoding="utf-8")
+    # --- end consumer ---
+
+    assert assets.count_dangling_refs(filed) == 0
+    refs = [r for r in assets.iter_image_refs(filed.read_text())
+            if assets.is_local_target(r.target)]
+    assert len(refs) == len(manifest)
+    assert all(r.target.startswith("attachments/") for r in refs)
+
+
+def test_manifest_line_numbers_survive_the_cleanup_pass(tmp_path, monkeypatch):
+    """Cleanup rewrites the markdown after the backend built the manifest.
+    A line number that describes the pre-cleanup text is a lie."""
+    pdf = fixtures.build_text_pdf(tmp_path, pages=2)
+    out = tmp_path / "out"
+    out.mkdir()
+    fixtures.patch_marker(monkeypatch, convert)
+
+    report = convert._apply_cleanup(convert.convert_with_marker(pdf, out))
+    md = out / f"{pdf.stem}.md"
+    lines = md.read_text(encoding="utf-8").splitlines()
+
+    for entry in report.assets:
+        for ref in entry["references"]:
+            assert ref["target"] in lines[ref["line"] - 1]

--- a/tests/test_extract_images_integration.py
+++ b/tests/test_extract_images_integration.py
@@ -30,12 +30,29 @@ def test_extract_images_writes_png_and_references_in_markdown(tmp_path):
     assert data["extracted_assets"] >= 1
 
 
-def test_extract_images_default_off(tmp_path):
-    """Without --extract-images, no asset dir should be produced."""
+def test_extract_images_default_on(tmp_path):
+    """Extraction is the default as of issue #34.
+
+    The old default found the figures, emitted references to them, and threw
+    the files away — a caller had to know a flag existed to avoid producing
+    broken output. Keeping the figures costs nothing that was not already
+    spent finding them.
+    """
     pdf = fixtures.build_figure_pdf(tmp_path)
     out_dir = tmp_path / "out"
     out_dir.mkdir()
 
-    convert.convert_with_pymupdf(pdf, out_dir)
+    report = convert.convert_with_pymupdf(pdf, out_dir)
+    assert (out_dir / f"{pdf.stem}_assets").is_dir()
+    assert report.extracted_assets >= 1
+
+
+def test_extract_images_opt_out(tmp_path):
+    """With extraction explicitly off, no asset dir should be produced."""
+    pdf = fixtures.build_figure_pdf(tmp_path)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    convert.convert_with_pymupdf(pdf, out_dir, extract_images=False)
     asset_dir = out_dir / f"{pdf.stem}_assets"
     assert not asset_dir.exists()


### PR DESCRIPTION
Closes #34.

## The mechanism

Two bugs in the marker backend's asset harvesting, either sufficient alone:

1. **The suffix.** Marker writes its figures as `.jpeg`. The harvesting code globbed `rglob("*.png")` and `rglob("*.jpg")` from marker's scratch tree. `fnmatch("_page_64_Figure_7.jpeg", "*.jpg")` is `False` — so the files were never found, and the scratch tree was a `TemporaryDirectory`, so they were deleted moments later.
2. **The slash.** The reference-rewriting regex was `!\[([^\]]*)\]\((?:[^)]*/)([^)]+)\)`. The `(?:[^)]*/)` group is not optional, so it only matches a target containing a directory separator. Marker's references are bare filenames. Even on the path where the files *were* found, the references would not have been repointed.

Both are bugs a test asserting "images get moved" passes over, because the code path is only reached when the glob matches. What catches them is asserting the *property*.

## Part 1 — which route, and why

**Both, at different layers.**

**Route 1 (primary): extraction becomes the default.** `--extract-images` now defaults on, with `--no-extract-images` as the opt-out. The decisive fact is that the figures are already extracted internally — marker finds them whether we ask or not, pymupdf's detector runs against pages already open — so the old default paid the full cost of finding a figure and then threw the file away. And per the issue: documenting the flag harder treats the symptom. The consuming runbook never mentioned `--extract-images`, so every ingest that followed the documented process produced broken output. A default requiring you to know a flag exists in order to avoid producing broken output is a bad default.

**Route 2 (backstop): refuse to emit a reference to an asset we did not write.** Every backend now ends in `_finalize_assets` → `assets.enforce_reference_invariant`, which strips any reference still pointing at nothing. Route 1 makes the invariant cheap to satisfy; **route 2 is what makes it true** — with extraction disabled, when a backend loses its assets, and for backends not yet written.

A stripped reference leaves `<!-- bookconvert: image omitted, asset not extracted: X -->`. Renders as nothing; means a thin conversion is diagnosable by a human rather than silent. The sidecar counts them in `dangling_refs_stripped` and adds a warning.

Both acceptance conditions hold, and are tested independently: no flags → assets written, zero dangling; extraction disabled → references stripped, zero dangling.

## Part 2 — the manifest

The sidecar gains an `assets` array:

```json
"assets": [
  {
    "path": "MyBook_images/_page_64_Figure_7.jpeg",
    "bytes": 48213,
    "references": [
      {"target": "MyBook_images/_page_64_Figure_7.jpeg", "alt": "", "line": 812}
    ]
  }
],
"extracted_assets": 1,
"dangling_refs_stripped": 0
```

- **`path`** — relative to the markdown file. Move this.
- **`bytes`** — for a consumer that wants to skip 200-byte ornaments.
- **`references`** — `target` is the link target *exactly as written*, so rewriting is a substitution of `](target)`; `line` is 1-indexed and accurate against the file as shipped (the manifest is recomputed after the cleanup pass, which rewrites the markdown underneath it).

An asset nothing references still gets an entry with `references: []` — that is the signature of a reference lost upstream, which is information.

`test_manifest_round_trip_relocates_every_asset` exercises the full trip: a consumer relocates every asset and rewrites every reference without looking at a filename, suffix, or page-number pattern.

## Backend coverage

I checked all six, not just marker.

| Backend | Emits refs? | Treatment |
|---|---|---|
| **marker** | Yes — bare `_page_N_Figure_M.jpeg`. **The one that broke.** | Harvest by suffix set, repoint by basename; `--disable_image_extraction` forwarded on the opt-out path only (an older marker that doesn't know the flag would abort, and that risk belongs to the caller who asked for text-only, never to the default) |
| **pymupdf** | Only when it has just written the file | Default flipped on. Structurally cannot dangle |
| **pymupdf4llm** | Yes, into `<stem>_images/` | `write_images` follows `extract_images` instead of being hardcoded on |
| **pandoc** (EPUB) | **Yes** — the epub's internal media, for images it never writes | **Also affected, by construction.** Route 2 only, deliberately — see below |
| **docling** | No (`<!-- image -->` placeholders) | Swept anyway |
| **ocr** | No | Swept anyway |

**Deliberately out of scope: extraction for EPUB.** Pandoc has `--extract-media` and route 1 was available, but the images an epub carries that survive `_clean_pandoc_output`'s existing empty-alt filter are overwhelmingly publisher furniture — covers, ornaments, imprint marks — and the epub path is documented as text-only. Extracting them would fight a filter that is there on purpose. EPUB gets route 2: the references are stripped. Happy to revisit if real epub figures turn out to matter.

## Testing

**310 passed, 8 skipped** (baseline on `main`: 287 passed, 8 skipped). 22 new tests + 1 existing test whose contract changed with the default.

No real marker run is involved — `fixtures.patch_marker` reproduces marker's *output shape* (bare `.jpeg` references, files beside the markdown in the scratch tree), which is the only part of marker this behaviour depends on. All fixtures are synthetic.

### Mutation check

Three mutations, each reverted after:

1. **`_finalize_assets` neutered entirely** → 6 failures (both marker harvest tests, both strip tests, all three manifest tests).
2. **`IMAGE_SUFFIXES` cut back to `{".png", ".jpg"}`** — the literal original bug → 5 failures, including `test_harvest_collects_jpeg_not_just_jpg` and `test_marker_with_no_flags_writes_the_figures_it_references`. Note that `test_marker_that_loses_its_assets_does_not_dangle` *passed* under this mutation, correctly: with the suffix bug the assets are lost but route 2 still holds the invariant. That is the layering working as designed.
3. **Route 2 alone disabled** → 3 failures, exactly the strip tests.

The mutation run also caught a **vacuous test of my own**: the first EPUB test passed under all three mutations, because `build_semantic_epub` carries no images. Replaced with `build_figure_epub` (alt-bearing `<img>` tags, which is what survives pandoc's empty-alt filter to dangle); it now fails under mutation 3, as it should.

## Something in the issue worth flagging

The issue frames this as *"the converter's default discards figures it has already extracted"* — true for pymupdf, but not the whole story for marker, which is where the 1,140 came from. Marker was never told to disable extraction and never had an `--extract-images` gate; it extracted the figures every time and then BookConvert dropped them on the floor between the temp directory and the output directory. So `--extract-images` would **not** have prevented the downstream damage — it doesn't reach the marker path at all. The fix had to be the harvesting bug plus the invariant; the default flip is right on its own merits but would have been a no-op for the 49 affected sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)