### PR TITLE
docs: correct the locator capability table — marker emits printed locators

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,13 @@ which you have:
 
 | `page_numbering` | Meaning | Backends |
 |---|---|---|
-| `printed` | Real page numbers were captured | `pymupdf`, when printed page numbers were actually found |
-| `pdf_only` | PDF page index only | `pymupdf` (no printed page numbers found), `pymupdf4llm`, `ocr` |
-| `none` | No locators emitted at all | `marker`, `pandoc` (EPUB), `docling` |
+| `printed` | Real page numbers were captured | `pymupdf` and `marker`, when printed page numbers were actually found |
+| `pdf_only` | PDF page index only | `pymupdf` / `marker` (no printed numbers found), `pymupdf4llm`, `ocr` |
+| `none` | No locators emitted at all | `pandoc` (EPUB — reflowable, no pages exist), `docling` |
 
-`pymupdf` is the only backend that can produce a citable page number, and it
-decides between `printed` and `pdf_only` at runtime. The other five have a
-fixed capability. Read `page_numbering` from the sidecar rather than
-assuming it from the `--method` you asked for.
+`pymupdf` and `marker` both decide between `printed` and `pdf_only` at runtime;
+the others have a fixed capability. Read `page_numbering` from the sidecar
+rather than assuming it from the `--method` you asked for.
 
 Where printed-page-number survival is sparse, `page_printed_offset` is
 derived from the captured samples and used to fill the gaps — but only


### PR DESCRIPTION
The `page_numbering` table claims marker emits `none`, and that "pymupdf is the only backend that can produce a citable page number." Both were accurate before #23 and have been wrong since.

**The document contradicts itself.** A few paragraphs below the table, the README describes marker's folio capture in detail — reading a numeral off a line shared with a running head, the 85% consensus rule, interpolation clamped to the captured span. All of that is marker behaviour, from #23 and #33.

**Verified against a real conversion**, not the code comments:

```
$ jq -r '.method + " -> page_numbering: " + .page_numbering' the-tao-of-coaching.report.json
marker -> page_numbering: printed
```

That's a 136-page home scan — precisely the case the table says is uncitable.

## Why this is worth a PR rather than a passing fix

A reader trusting the table concludes a scanned book cannot be cited by page. That is the opposite of true, and it is the single capability the downstream research corpus depends on — the whole point of #23, #29, #31 and #33 was making home-scanned books page-citable. The stale table quietly tells people that work doesn't exist.

Docs-only, +7/−8. Suite green.