### PR TITLE
Catch a venv console script whose interpreter is gone

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -107,6 +107,25 @@ def check_dependencies(method):
                 "Missing dependency: marker-pdf (pip install marker-pdf).\n"
                 f"  Looked for `marker_single` in {venv_bin} and on PATH."
             )
+        # The binary exists -- but a venv console script hardcodes its
+        # interpreter, so "exists" is not "runnable" after a directory rename.
+        # Check before a long conversion rather than after it fails to start.
+        _found = marker_bin if marker_bin.exists() else Path(marker_on_path)
+        _dead = _stale_shebang(_found)
+        if _dead is not None:
+            _bin_dir = _found.parent
+            raise DependencyError(
+                f"`{_found}` points at an interpreter that does not exist:\n"
+                f"    {_dead}\n"
+                "  This is what a moved or renamed project directory looks like -- the\n"
+                "  script is present but every spawn fails with `bad interpreter`.\n"
+                "  Repair the shebangs in place (line 1 only):\n"
+                f"    grep -rl '{_dead}' {_bin_dir} | while read f; do \\\n"
+                f"      sed -i '' \"1s|{_dead}|$(command -v python3)|\" \"$f\"; done\n"
+                "  Or rebuild the venv from scratch:\n"
+                f"    python3.12 -m venv --clear {_bin_dir.parent} && "
+                f"{_bin_dir}/pip install marker-pdf"
+            )
         # If the venv-sibling binary exists but isn't on PATH, add it so
         # convert_with_marker() can spawn it via plain subprocess.run.
         if marker_bin.exists() and marker_on_path is None:
@@ -194,6 +213,42 @@ def check_dependencies(method):
                 "Missing dependency: pandoc (brew install pandoc)\n"
                 "  EPUB conversion uses pandoc to preserve chapter structure."
             )
+
+
+def _stale_shebang(script_path):
+    """Return the dead interpreter path if `script_path`'s shebang is broken.
+
+    A venv console script hardcodes an absolute interpreter path on line 1.
+    Move or rename the project directory and every one of those scripts keeps
+    pointing at the old location: the file still exists, `shutil.which` still
+    finds it, and it still fails the moment it is spawned, with a `bad
+    interpreter` error from the kernel that never mentions the rename.
+
+    That is not hypothetical. Renaming BookConvert to sourceconvert on
+    2026-07-28 left 73 stale scripts in `.venv-marker/bin` and 42 in
+    `.venv/bin`, and the next ingest died instantly on `marker_single`. The
+    existence check above cannot catch it, so it is checked here.
+
+    Returns None when the shebang is fine, unreadable, or not a shebang at
+    all -- this is a diagnostic, and it must never be the reason a working
+    conversion refuses to start.
+    """
+    try:
+        with open(script_path, "rb") as fh:
+            first = fh.readline(512)
+    except OSError:
+        return None
+    if not first.startswith(b"#!"):
+        return None
+    line = first[2:].decode("utf-8", "replace").strip()
+    if not line:
+        return None
+    # `#!/usr/bin/env python3` delegates the lookup to env -- nothing absolute
+    # to verify, and env will resolve it against PATH at spawn time.
+    interp = line.split()[0]
+    if not interp.startswith("/") or Path(interp).name == "env":
+        return None
+    return None if Path(interp).exists() else interp
 
 
 def _marker_available():

--- a/tests/test_stale_shebang.py
+++ b/tests/test_stale_shebang.py
@@ -1,0 +1,106 @@
+"""Tests for stale-venv-shebang detection.
+
+Renaming the project directory leaves every venv console script pointing at an
+interpreter that no longer exists. The script still exists and `shutil.which`
+still finds it, so the existence check in check_dependencies() passes and the
+failure only surfaces when the binary is spawned -- as a `bad interpreter`
+error that never mentions the rename. These cover the detector that closes
+that gap.
+"""
+import os
+import sys
+
+import pytest
+
+import convert
+
+
+def _script(tmp_path, name, first_line):
+    p = tmp_path / name
+    p.write_text(first_line + "\n# body\n")
+    p.chmod(0o755)
+    return p
+
+
+def test_dead_absolute_interpreter_is_reported(tmp_path):
+    """The real failure: shebang names an absolute path that is gone."""
+    dead = "/Users/nobody/projects/BookConvert/.venv-marker/bin/python3.12"
+    s = _script(tmp_path, "marker_single", f"#!{dead}")
+    assert convert._stale_shebang(s) == dead
+
+
+def test_live_absolute_interpreter_is_not_reported(tmp_path):
+    """A shebang pointing at a real interpreter is fine."""
+    s = _script(tmp_path, "marker_single", f"#!{sys.executable}")
+    assert convert._stale_shebang(s) is None
+
+
+def test_env_shebang_is_not_reported(tmp_path):
+    """`/usr/bin/env python3` resolves against PATH at spawn time.
+
+    There is no absolute interpreter to verify, so claiming it is stale would
+    be a false positive that blocks a working conversion.
+    """
+    s = _script(tmp_path, "marker_single", "#!/usr/bin/env python3")
+    assert convert._stale_shebang(s) is None
+
+
+def test_relative_interpreter_is_not_reported(tmp_path):
+    """Only absolute paths are checkable; anything else is left alone."""
+    s = _script(tmp_path, "marker_single", "#!python3")
+    assert convert._stale_shebang(s) is None
+
+
+def test_non_shebang_file_is_not_reported(tmp_path):
+    """A binary or a plain file must not be diagnosed as a broken script."""
+    s = _script(tmp_path, "marker_single", "not a shebang at all")
+    assert convert._stale_shebang(s) is None
+
+
+def test_missing_file_is_not_reported(tmp_path):
+    """Unreadable path returns None rather than raising.
+
+    This is a diagnostic run inside a dependency check; it must never be the
+    reason a conversion refuses to start.
+    """
+    assert convert._stale_shebang(tmp_path / "does-not-exist") is None
+
+
+def test_empty_file_is_not_reported(tmp_path):
+    s = tmp_path / "marker_single"
+    s.write_text("")
+    assert convert._stale_shebang(s) is None
+
+
+def test_shebang_with_arguments_uses_the_interpreter(tmp_path):
+    """`#!/path/to/python -u` -- the interpreter is the first token."""
+    dead = "/gone/bin/python3.12"
+    s = _script(tmp_path, "marker_single", f"#!{dead} -u")
+    assert convert._stale_shebang(s) == dead
+
+
+def test_check_dependencies_raises_on_stale_marker(tmp_path, monkeypatch):
+    """End to end: a stale marker_single beside sys.executable is caught.
+
+    Without this, check_dependencies() passes and the conversion dies minutes
+    later with an error that does not name the cause.
+    """
+    if sys.version_info < (3, 10):
+        pytest.skip("marker path requires Python 3.10+")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "python").write_text("#!/bin/sh\n")
+    dead = "/Users/nobody/projects/BookConvert/.venv-marker/bin/python3.12"
+    _script(fake_bin, "marker_single", f"#!{dead}")
+
+    monkeypatch.setattr(sys, "executable", str(fake_bin / "python"))
+    # Keep the PATH lookup from finding a healthy marker_single elsewhere.
+    monkeypatch.setenv("PATH", str(fake_bin))
+
+    with pytest.raises(convert.DependencyError) as exc:
+        convert.check_dependencies("marker")
+
+    msg = str(exc.value)
+    assert "bad interpreter" in msg
+    assert dead in msg


### PR DESCRIPTION
Renaming `BookConvert` to `sourceconvert` left **73 stale scripts** in `.venv-marker/bin` and **42** in `.venv/bin`. Each hardcodes an absolute interpreter path on line 1, so after the rename `marker_single` still existed, `shutil.which` still found it, `check_dependencies` still passed — and the spawn died with a kernel `bad interpreter` error that never mentions the rename.

That blocked the 2026-07-29 four-book ingest before a single page converted. A 90-second calibration run is the only reason it was caught before a four-hour chain.

## The fix

`_stale_shebang()` reads **line 1 only** and reports the interpreter if it does not exist. The existing check is deliberately a static existence check (`marker_single --help` loads ML models and takes 30+ seconds), so it structurally cannot see this — hence a separate cheap check rather than a change to that one.

It returns `None` for an unreadable file, a non-shebang, a relative interpreter, and `/usr/bin/env python3` (which resolves against PATH at spawn time). This is a diagnostic inside a dependency check and must never be the reason a working conversion refuses to start.

`check_dependencies("marker")` now names the dead path and spells out both repairs — sed the shebangs in place, or rebuild the venv.

## Tests

9 new tests covering the dead absolute path, the live path, `env`, relative, non-shebang, missing file, empty file, shebang-with-arguments, and an end-to-end `check_dependencies` raise. **325 passed, 2 skipped** — no regressions.

Found during the four-book SourceLibrary ingest; see `mc-wiki/log.md` 2026-07-29.