### PR TITLE
Don't read a contents page's listed number as its folio

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -1377,8 +1377,33 @@ def _strip_marker_page_furniture(page_text, header_lines, footer_lines):
                 return folio
         return None
 
-    folio = (first_folio(head_band)
-             or first_folio(foot_band)
+    # A page that lists page numbers — a contents or index page — carries
+    # several lines that are shaped exactly like a folio and are not one. The
+    # standing-alone preference below is right everywhere else and exactly
+    # backwards here: on What Works sheet 7 the head band holds both
+    # `viii Contents` (the real running head, real folio) and a bare `44` from
+    # the listing, and the bare number wins.
+    #
+    # Plurality is the discriminator, and it is a strong one: a page has one
+    # folio, so a second standalone folio-shaped line means at least one of
+    # them is not a folio, and nothing about shape says which. Measured over
+    # the four books ingested 2026-07-29, no body page anywhere reached two —
+    # the rule fires only on the four What Works contents pages and one
+    # Landsberg index page, whose captured value interpolation reproduces
+    # exactly. So this cannot alter a book that does not list page numbers.
+    #
+    # When it fires, fall through to the running-head folio, which is
+    # corroborated by recurring furniture and is therefore still trustworthy.
+    # If there is none, capture nothing and let interpolation fill the page:
+    # an honest gap beats a confident wrong number.
+    bare_folio_lines = sum(1 for l in page_text.split('\n')
+                           if _is_marker_folio(l.strip()))
+    lists_page_numbers = bare_folio_lines > 1
+
+    folio = None
+    if not lists_page_numbers:
+        folio = first_folio(head_band) or first_folio(foot_band)
+    folio = (folio
              or first_embedded_folio(head_band, header_lines)
              or first_embedded_folio(foot_band, footer_lines))
 

--- a/tests/test_contents_page_folio.py
+++ b/tests/test_contents_page_folio.py
@@ -1,0 +1,181 @@
+"""A contents or index page must not yield a listed page number as its folio.
+
+Such a page carries several lines shaped exactly like a folio that are not
+one. Capture used to prefer any bare folio-shaped line over a folio embedded
+in a running head, which is right on an ordinary page and backwards here.
+
+Real case: Bohnet's *What Works* (ingested 2026-07-29). Its five contents
+sheets emitted page_printed 1, 44, 123, 266 and 285 where the printed folios
+are roman. Five adjacent bad captures then defeated offset derivation for the
+whole book, so nothing downstream could interpolate either.
+"""
+import convert
+
+
+HEAD = {"viii Contents", "Contents"}
+
+
+def _strip(page_text, header=HEAD, footer=frozenset()):
+    return convert._strip_marker_page_furniture(page_text, header, footer)
+
+
+# --- the regression itself -------------------------------------------------
+
+def test_contents_page_does_not_emit_a_listed_number_as_the_folio():
+    """What Works sheet 7, verbatim in shape.
+
+    The band holds the real folio (roman, in the running head) and a listed
+    number. Before the fix this emitted `44`.
+
+    It does not recover `viii`, and that is deliberate. The embedded-folio
+    regexes match arabic only, and widening them to roman is not free: the
+    roman grammar is a letter-bag that also matches English words, so
+    `I Introduction` or `Civil War` in a running head would start producing
+    folios. That enhancement carries its own false-positive risk and belongs
+    in its own change. Here the harm is a confident wrong number, and the
+    fix is to stop emitting one.
+    """
+    page = (
+        "viii Contents\n"
+        "\n"
+        "# 2. De-Biasing Minds Is Hard\n"
+        "\n"
+        "44\n"
+        "\n"
+        "How to know when to settle; self-serving bias; halos and hindsight\n"
+        "\n"
+        "#### 3. Doing It Yourself Is Risky\n"
+        "\n"
+        "62\n"
+    )
+    folio, _body = _strip(page)
+    assert folio != "44"
+    assert folio is None
+
+
+def test_arabic_running_head_folio_still_wins_on_a_contents_page():
+    """Where the running head folio IS capturable, it must be preferred.
+
+    This is the path the suppression falls through to, so it needs a test
+    that does not depend on the roman gap above.
+    """
+    page = (
+        "108 Contents\n"
+        "\n"
+        "# 2. De-Biasing Minds Is Hard\n"
+        "\n"
+        "44\n"
+        "\n"
+        "How to know when to settle; self-serving bias\n"
+        "\n"
+        "#### 3. Doing It Yourself Is Risky\n"
+        "\n"
+        "62\n"
+    )
+    folio, _body = _strip(page, header={"Contents"})
+    assert folio == "108"
+
+
+def test_rule_needs_a_plurality_of_listed_numbers():
+    """The discriminator is plurality, and the limit is worth stating.
+
+    A contents page listing exactly one entry still looks like an ordinary
+    page carrying one folio, and is still mis-captured. Real contents pages
+    list many -- What Works' had four apiece -- so this is a residual, not the
+    observed failure. Recorded as a test so it is a known edge rather than a
+    surprise.
+    """
+    page = "# 6. Orchestrating Smarter Evaluation Procedures\n\n123\n\nPink is for tax bills\n"
+    folio, _body = _strip(page, header=frozenset())
+    assert folio == "123"      # not yet distinguishable from a real folio
+
+
+def test_contents_page_with_no_running_head_captures_nothing():
+    """What Works sheet 8: no running head survived, several listed numbers.
+
+    There is nothing trustworthy to capture, so capture nothing and let
+    interpolation fill it. A gap is honest; 123 would be a confident lie.
+    """
+    page = (
+        "# 6. Orchestrating Smarter Evaluation Procedures\n"
+        "\n"
+        "123\n"
+        "\n"
+        "Pink is for tax bills; why Lakisha needs a longer resume than Emily\n"
+        "\n"
+        "#### 7. Attracting the Right People\n"
+        "\n"
+        "146\n"
+    )
+    folio, _body = _strip(page)
+    assert folio is None
+
+
+def test_index_page_captures_nothing_rather_than_an_entry_number():
+    """An index page is the same shape: wrapped entries leave bare numbers."""
+    page = (
+        "# Index\n"
+        "\n"
+        "Leadership\n"
+        "books about,\n"
+        "120\n"
+        "\n"
+        "Learning, books about,\n"
+        "119\n"
+    )
+    folio, _body = _strip(page, header=frozenset())
+    assert folio is None
+
+
+# --- the property that makes the rule safe ---------------------------------
+
+def test_ordinary_page_with_one_standalone_folio_is_unchanged():
+    """The common case must be untouched: exactly one folio-shaped line."""
+    page = (
+        "42\n"
+        "\n"
+        "The manager's output is the output of the organisation under her.\n"
+    )
+    folio, body = _strip(page, header=frozenset())
+    assert folio == "42"
+    assert "manager's output" in body
+
+
+def test_folio_in_foot_band_still_captured():
+    """The Alliance runs its folio at the foot; that path must still work."""
+    page = (
+        "Employment in the Networked Age\n"
+        "\n"
+        "A tour of duty is a mutual pact.\n"
+        "\n"
+        "9\n"
+    )
+    folio, _body = _strip(page, header=frozenset(), footer=frozenset())
+    assert folio == "9"
+
+
+def test_body_page_quoting_a_single_number_is_unchanged():
+    """One standalone number plus a real folio is two -- but this is the
+    boundary the rule accepts as the price of correctness.
+
+    A page whose body quotes a bare number loses its capture and falls back to
+    interpolation. That is a coverage cost, never a correctness one, and it is
+    the direction the runbook prefers to err.
+    """
+    page = (
+        "17\n"
+        "\n"
+        "The result was unambiguous:\n"
+        "\n"
+        "94\n"
+        "\n"
+        "percent of respondents agreed.\n"
+    )
+    folio, _body = _strip(page, header=frozenset(), footer=frozenset())
+    assert folio is None
+
+
+def test_roman_folio_alone_still_captured():
+    page = "xvii\n\nPreface to the second edition\n"
+    folio, _body = _strip(page, header=frozenset())
+    assert folio == "xvii"


### PR DESCRIPTION
A contents or index page carries several lines shaped exactly like a folio that are not one. Capture preferred any **bare** folio-shaped line over a folio **embedded in a running head** — correct on an ordinary page, backwards here.

## What it cost

Bohnet's *What Works* (ingested 2026-07-29) shows both halves:

- **Sheet 7** — the head band holds `viii Contents` (the real running head, the real folio) *and* a bare `44` from the listing. The bare number won.
- **Sheets 6–10** emitted printed pages `1, 44, 123, 266, 285` where the printed folios are roman.

Those five bad captures were **adjacent**, which is precisely the signature the offset deriver treats as a page-order defect — so it refused to derive an offset for the whole book, and nothing downstream could interpolate either. One contents section cost a 400-page book its pagination.

## The discriminator

Plurality. A page has one folio, so a second standalone folio-shaped line means at least one of them is not a folio, and shape cannot say which. When that happens, fall through to the running-head folio (corroborated by recurring furniture); if there is none, capture nothing and let interpolation fill the page. **An honest gap beats a confident wrong number.**

## Why it is safe

Measured across all four books ingested 2026-07-29 (1,142 pages):

| book | pages with >1 standalone folio-shaped line |
|---|---|
| the-alliance | 0 |
| mind-over-machine | 0 |
| high-output-management | 0 |
| what-works | 4 (the contents pages) |
| landsberg-tao-of-coaching | 1 (the index page) |

No body page anywhere reached two. The rule **cannot alter a book that does not list page numbers**, which preserves the property the existing docstring prizes. On the Landsberg index page the suppressed value is exactly what interpolation reproduces at offset 9, so it costs nothing there either.

## Verified end to end

Reconverting What Works sheets 4–12 takes captures from `{6:1, 7:44, 8:123, 9:201, 10:285}` to `{10:285}`. The survivor is a contents page listing a single entry — still shaped like an ordinary page, covered by a test as a known residual. With one outlier instead of five adjacent ones, the existing consensus rule handles it the way it already handles the Alliance's sheet 179.

## Deliberately not fixed here

The embedded-folio regexes match **arabic only**, so a roman folio in a running head (`viii Contents`) is suppressed rather than recovered. Widening them is not free: the roman grammar is a letter-bag that also matches English words, so `I Introduction` or `Civil War` in a running head would start producing folios. That belongs in its own change with its own evidence.

**325 passed, 2 skipped** — no regressions.