### PR TITLE
Finish the rename tail: stale issue slugs and live recommendations

### DIFF
--- a/docs/bookconvert-improvements-plan-2026-04-15.md
+++ b/docs/bookconvert-improvements-plan-2026-04-15.md
@@ -1,5 +1,16 @@
 # BookConvert Improvements Implementation Plan
 
+> **COMPLETED 2026-04. This is a record, not live work — do not execute it.**
+> Every deliverable shipped: `assets.py`, `report.py`, the `pymupdf4llm` and
+> `docling` backends, the JSON sidecar and the per-backend requirements files
+> all exist on `main`. The instruction below is preserved as authored and no
+> longer applies.
+>
+> The title and filename say **BookConvert** because that was the project's name
+> when this was written; it is `sourceconvert` now
+> (`8-DECISIONS/2026-07-28-rename-to-sourceconvert.md`). History is preserved as
+> authored, so the old name stands here rather than being rewritten.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a pymupdf4llm backend, a Docling backend, a figure/image extraction pipeline, a JSON sidecar conversion report, better OCR routing, and an extras-style install path for heavy ML backends. Close the biggest quality gap surfaced by the `Dont Make Me Think` run (graphics flattened into text) and give BookConvert a second-opinion backend for visual-heavy books.

--- a/docs/paper-extraction-research.md
+++ b/docs/paper-extraction-research.md
@@ -1,6 +1,6 @@
 # Paper Extraction Research
 
-Survey of tools that handle academic-paper PDF → text conversion, focused on how each tool tackles the column-layout problem and what BookConvert could borrow.
+Survey of tools that handle academic-paper PDF → text conversion, focused on how each tool tackles the column-layout problem and what sourceconvert could borrow.
 
 **Our constraints:**
 - Default venv is Python 3.9 (marker-pdf and several modern tools require 3.10+).
@@ -163,8 +163,8 @@ Survey of tools that handle academic-paper PDF → text conversion, focused on h
 - Hit-or-miss on older / non-STEM papers. We'd need to test on our corpus.
 
 **What we can borrow.**
-- The element-typing idea is worth adding to BookConvert's post-processing: when we emit a line, we already know from geometry whether it's a running header, body, or full-width block. We could expose that as semantic markdown (H1/H2/H3) more systematically.
-- Their fallback cascade (fast → hi_res → OCR) is a good pattern for BookConvert's existing `pymupdf → marker → ocr` structure.
+- The element-typing idea is worth adding to sourceconvert's post-processing: when we emit a line, we already know from geometry whether it's a running header, body, or full-width block. We could expose that as semantic markdown (H1/H2/H3) more systematically.
+- Their fallback cascade (fast → hi_res → OCR) is a good pattern for sourceconvert's existing `pymupdf → marker → ocr` structure.
 
 **Verdict.** A viable alternative to marker for users who prefer a more mainstream Python dep. Worth a mention in the decision doc but not worth making it the default when marker is available.
 
@@ -233,7 +233,7 @@ Survey of tools that handle academic-paper PDF → text conversion, focused on h
 
 ---
 
-## Specific recommendations for BookConvert
+## Specific recommendations for sourceconvert
 
 1. **Default path stays PyMuPDF + our enhanced column detection** (Approach B). It works in Python 3.9, has no external deps, and already handles 43/43 of our corpus as of the checkpoint commit.
 

--- a/docs/quality-fallback-design.md
+++ b/docs/quality-fallback-design.md
@@ -1,6 +1,6 @@
 # Quality-Gated OCR Auto-Fallback Design
 
-**Issue:** AndySparks/book-convert#17
+**Issue:** AndySparks/sourceconvert#17
 **Date:** 2026-04-09
 **Status:** Design approved, implementation in progress
 **Revision 2026-04-09:** Scorer redesigned mid-implementation. Wordlist-based

--- a/docs/quality-fallback-plan.md
+++ b/docs/quality-fallback-plan.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Python 3.7+, PyMuPDF (fitz), pytest (new dev dependency), `/usr/share/dict/words` (BSD/macOS/Linux system wordlist)
 
-**Related docs:** `docs/quality-fallback-design.md`, issue AndySparks/book-convert#17
+**Related docs:** `docs/quality-fallback-design.md`, issue AndySparks/sourceconvert#17
 
 ---
 
@@ -630,7 +630,7 @@ the existing 'scanned' match, so degraded extractions (e.g. PDFs with
 non-standard font encodings like The Pyramid Principle) now route to
 OCR automatically instead of silently shipping garbled output.
 
-Fixes AndySparks/book-convert#17
+Fixes AndySparks/sourceconvert#17
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 EOF
@@ -808,7 +808,7 @@ If the repo has CI configured (check `.github/workflows/`), wait for it to go gr
 - [ ] **Step 2: Close issue #17 with a reference to the fix commit**
 
 ```bash
-gh issue close 17 --repo AndySparks/book-convert --comment "Fixed by the quality-gated OCR auto-fallback. See commit message on main for details; design doc at docs/quality-fallback-design.md."
+gh issue close 17 --repo AndySparks/sourceconvert --comment "Fixed by the quality-gated OCR auto-fallback. See commit message on main for details; design doc at docs/quality-fallback-design.md."
 ```
 
 - [ ] **Step 3: Announce completion to the user**


### PR DESCRIPTION
Follow-on to `8-DECISIONS/2026-07-28-rename-to-sourceconvert.md`, prompted by Andy noticing the project felt unfinished. He was right, and the audit found the gap is narrower and more interesting than "the sweep missed some strings".

The original gate was the right one — *execute every documented command*, not "grep is clean". What it structurally could not reach:

**1. Machine-readable config** (fixed outside this PR — `.claude/settings.local.json` is untracked). Eight Bash permission grants pointed at `/Users/andysparks/Documents/Claude/projects/BookConvert/...`, a path that no longer exists. Local-only, so no repo sweep could see it; the effect was permission prompts for commands that should be pre-approved.

**2. A `docs/` tail that reads as instruction rather than record:**

| file | what | why it is in scope |
|---|---|---|
| `quality-fallback-design.md`, `quality-fallback-plan.md` | 4× `AndySparks/book-convert#17`, one inside a runnable `gh issue close --repo` | GitHub redirects the old slug so nothing is broken — but the canonical name is what a reader copies. Verified issue 17 resolves under the new slug. |
| `paper-extraction-research.md` | "worth adding to **BookConvert**s post-processing", "Specific recommendations for **BookConvert**" | Forward-looking recommendations are exactly the instruct-future-behaviour class the decision says to sweep. |
| `bookconvert-improvements-plan-2026-04-15.md` | opens with "REQUIRED SUB-SKILL: implement this plan task-by-task" | **Completed** in 2026-04 — `assets.py`, `report.py` and both new backends are on `main`. Body and filename left as authored per "history is preserved"; a banner now says it shipped so nobody works it again. |

**Deliberately not touched:** `tests/test_stale_shebang.py` and the `convert.py` comment both name BookConvert on purpose — they document the rename as the cause of the bug they guard against. Rewriting them would erase the explanation.

**334 passed, 2 skipped.**

Also surfaced, outside this repo and not fixed here: the `operating-system` repo was never in the rename decisions declared scope and still carries live references, including a `cd` to the dead path in `7-RUNBOOKS/start.md`. Reported to Andy separately.