### PR TITLE
Validate marker's interpreter at the spawn, not behind --skip-check

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -3466,6 +3466,29 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None,
         # Newer marker-pdf releases (≥1.0) take the output path via the
         # `--output_dir` flag rather than as a second positional argument.
         # Passing it positionally raises "Got unexpected extra argument".
+        # Validate the interpreter here, at the spawn, and not only in
+        # check_dependencies() -- which `--skip-check` skips, and which every
+        # documented invocation passes (`ingest-batch.sh`, and four places in
+        # source-ingestion.md). A guard that only covers the path nobody takes
+        # is not a guard. Proven on 2026-07-29: sourceconvert moved to
+        # ~/conductor/repos, all 125 venv scripts kept pointing at the old
+        # location, and the check added that same morning could not fire.
+        _marker_path = shutil.which("marker_single")
+        if _marker_path:
+            _dead = _stale_shebang(_marker_path)
+            if _dead is not None:
+                _old_root = _dead.split("/.venv")[0]
+                raise ConversionError(
+                    f"`{_marker_path}` points at an interpreter that does not exist:\n"
+                    f"    {_dead}\n"
+                    "  The venv was built at a different path — this is what a moved or\n"
+                    "  renamed project directory looks like. Repair the venv's absolute\n"
+                    "  paths (shebangs, and VIRTUAL_ENV in the activate scripts):\n"
+                    f"    OLD={_old_root}\n"
+                    "    NEW=$(pwd)\n"
+                    '    grep -rl "$OLD" .venv/bin .venv-marker/bin '
+                    '| while read f; do sed -i "" "s|$OLD|$NEW|g" "$f"; done'
+                )
         cmd = ["marker_single", str(pdf_path), "--output_dir", tmpdir]
         # Page-locator flags go on unconditionally: a source filed without a
         # citable address cannot be fixed later without reconverting, and

--- a/scripts/extract_hbr.sh
+++ b/scripts/extract_hbr.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Extract individual HBR articles from the collection into ~/Vaults/Wiki/raw/
 
-SRC="/Users/andysparks/Documents/Claude/projects/sourceconvert/output/HBR_s 10 Must Reads for New Managers Collection.md"
+SRC="/Users/andysparks/conductor/repos/sourceconvert/output/HBR_s 10 Must Reads for New Managers Collection.md"
 RAW="$HOME/Vaults/Wiki/raw"
-CONVERT="/Users/andysparks/Documents/Claude/projects/sourceconvert/convert.py"
+CONVERT="/Users/andysparks/conductor/repos/sourceconvert/convert.py"
 COUNT=0
 
 # Step 1: Save full collection as one raw file

--- a/tests/test_stale_shebang.py
+++ b/tests/test_stale_shebang.py
@@ -104,3 +104,45 @@ def test_check_dependencies_raises_on_stale_marker(tmp_path, monkeypatch):
     msg = str(exc.value)
     assert "bad interpreter" in msg
     assert dead in msg
+
+
+# --- the guard must cover the path people actually take --------------------
+
+def test_marker_spawn_rejects_a_dead_interpreter_even_with_skip_check(tmp_path, monkeypatch):
+    """`--skip-check` skips check_dependencies, so the spawn must check too.
+
+    Every documented invocation passes --skip-check: mc-wiki's
+    ingest-batch.sh and four places in source-ingestion.md. When sourceconvert
+    moved to ~/conductor/repos on 2026-07-29, all 125 venv scripts kept
+    pointing at the old location and the check added that same morning could
+    not fire, because it lived behind the flag everyone sets.
+    """
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    dead = "/Users/nobody/Documents/Claude/projects/sourceconvert/.venv-marker/bin/python3.12"
+    s = fake_bin / "marker_single"
+    s.write_text(f"#!{dead}\n")
+    s.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+
+    pdf = tmp_path / "x.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+
+    with pytest.raises(convert.ConversionError) as exc:
+        convert.convert_with_marker(pdf, tmp_path / "out")
+
+    msg = str(exc.value)
+    assert dead in msg
+    # The repair hint must name the old root so the sed is copy-pasteable.
+    assert "/Users/nobody/Documents/Claude/projects/sourceconvert" in msg
+
+
+def test_marker_spawn_allows_a_healthy_interpreter(tmp_path, monkeypatch):
+    """The guard must not block a working marker: no raise before spawn."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    s = fake_bin / "marker_single"
+    s.write_text(f"#!{sys.executable}\n")
+    s.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    assert convert._stale_shebang(s) is None


### PR DESCRIPTION
PR #37 added a check for a venv console script whose interpreter no longer exists. It lived in `check_dependencies()`, **which `--skip-check` skips** — and every documented invocation passes that flag: mc-wiki's `ingest-batch.sh`, and four places in `source-ingestion.md`.

So the guard covered the one path nobody takes. **That was proven the same day it landed.**

On 2026-07-29 sourceconvert moved from `~/Documents/Claude/projects` to `~/conductor/repos`. All **125** scripts across both venvs kept pointing at the old location, `marker_single` could not start, and the check added that morning never fired.

## The fix

Validation now runs in `convert_with_marker()`, immediately before the spawn, where it cannot be skipped. The error names the dead interpreter and emits a copy-pasteable repair.

## The repair hint covers both classes this time

The 2026-07-28 sweep fixed **only line-1 shebangs**. That was enough then, because `marker_single` is spawned directly. But `VIRTUAL_ENV` is also hardcoded — in `activate`, `activate.csh`, `activate.fish` — and the runbook tells you to `source .venv-marker/bin/activate`. A line-1-only sweep leaves a venv that half works: direct spawns fine, sourced activation silently pointing at a directory that no longer exists.

This move produced 118 stale shebangs **and** 7 stale `VIRTUAL_ENV` assignments. Both are now named in the hint.

Also repoints `scripts/extract_hbr.sh` at the new canonical path.

**336 passed, 2 skipped.** Two new tests: the spawn rejects a dead interpreter with `--skip-check` in play, and a healthy one is untouched.