### PR TITLE
A space in the source filename no longer breaks its figure refs

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -3543,7 +3543,20 @@ def convert_with_marker(pdf_path, output_dir, marker_args=None,
         # before the TemporaryDirectory takes them to the grave. A previous
         # conversion of the same book owns nothing here, so clear the
         # directory rather than merging two runs' assets into it.
-        img_dest = output_dir / f"{pdf_path.stem}_images"
+        # Spaces are squeezed out of the asset directory name, matching what the
+        # pymupdf4llm backend already does. A space in the directory makes every
+        # reference marker emits unusable: `![](A Spaced Name_images/x.jpeg)` is
+        # not a valid CommonMark link destination, and consumers stop at the
+        # first whitespace — mc-wiki's check-figures.py captures only "A" and
+        # reports the figure dangling, while the file sits on disk beside it.
+        #
+        # Percent-encoding and angle-bracket wrapping are both more standards-
+        # correct and both wrong here: that consumer resolves a ref as a literal
+        # path with no URL-decoding, so either would still fail to find the file.
+        # Renaming the directory is the only fix that needs no consumer changed,
+        # and the name is generated rather than meaningful.
+        safe_stem = re.sub(r"\s+", "_", pdf_path.stem)
+        img_dest = output_dir / f"{safe_stem}_images"
         if img_dest.exists():
             shutil.rmtree(str(img_dest))
 

--- a/tests/test_spaced_filename_assets.py
+++ b/tests/test_spaced_filename_assets.py
@@ -1,0 +1,66 @@
+"""A space in the source filename must not break its figure references.
+
+marker named the asset directory after the raw stem, so a source called
+"A Spaced Name.pdf" produced `![](A Spaced Name_images/_page_0_Picture_0.jpeg)`.
+That is not a valid CommonMark link destination — an unescaped space ends it —
+and consumers stop at the first whitespace. mc-wiki's check-figures.py captures
+only "A", reports the figure dangling, and the file sits on disk beside it.
+
+Found 2026-07-29 while testing the Phase 5 pipeline, which converts whatever
+lands in the inbox and so meets scanner filenames with spaces routinely. The
+pymupdf4llm backend had already solved this with `safe_stem`; the marker backend
+never got it.
+
+Percent-encoding and angle-bracket wrapping are both more standards-correct and
+both wrong here: the consumer resolves a ref as a literal path with no
+URL-decoding, so either would still fail to find the file. Renaming the
+generated directory is the only fix that needs no consumer changed.
+"""
+import re
+
+import convert
+
+
+def test_safe_stem_squeezes_whitespace():
+    assert re.sub(r"\s+", "_", "A Spaced Name") == "A_Spaced_Name"
+    assert re.sub(r"\s+", "_", "The Person and the Situation") == \
+        "The_Person_and_the_Situation"
+
+
+def test_unspaced_stem_is_untouched():
+    """The common case must be byte-identical — this cannot rename anything."""
+    for stem in ("accidental-empires", "simonton-greatness", "what-works"):
+        assert re.sub(r"\s+", "_", stem) == stem
+
+
+def test_a_spaced_ref_is_unreadable_by_the_consumer_pattern():
+    """Why the rename is necessary, pinned as a test rather than a comment.
+
+    This is mc-wiki's check-figures.py pattern. Against a spaced destination it
+    captures a truncated path, which is why the figure reads as dangling.
+    """
+    img_re = re.compile(r"!\[[^\]]*\]\(([^)\s]+)")
+
+    spaced = "![](A Spaced Name_images/_page_0_Picture_0.jpeg)"
+    assert img_re.findall(spaced) == ["A"]          # truncated → resolves to nothing
+
+    safe = "![](A_Spaced_Name_images/_page_0_Picture_0.jpeg)"
+    assert img_re.findall(safe) == ["A_Spaced_Name_images/_page_0_Picture_0.jpeg"]
+
+
+def test_percent_encoding_would_not_have_helped():
+    """Records why the standards-correct fix was rejected.
+
+    The consumer does `(md.parent / ref).exists()` with no unquoting, so a
+    percent-encoded destination parses cleanly and then resolves to a path that
+    does not exist. Angle brackets fail earlier, on the same whitespace rule.
+    """
+    img_re = re.compile(r"!\[[^\]]*\]\(([^)\s]+)")
+
+    encoded = "![](A%20Spaced%20Name_images/x.jpeg)"
+    ref = img_re.findall(encoded)[0]
+    assert ref == "A%20Spaced%20Name_images/x.jpeg"
+    assert "%20" in ref                    # a literal path segment, not a space
+
+    angled = "![](<A Spaced Name_images/x.jpeg>)"
+    assert img_re.findall(angled) == ["<A"]


### PR DESCRIPTION
marker named the asset directory after the raw stem, so `A Spaced Name.pdf` produced:

```
![](A Spaced Name_images/_page_0_Picture_0.jpeg)
```

An unescaped space ends a CommonMark link destination, so that reference is unusable. mc-wiki's `check-figures.py` uses `!\[[^\]]*\]\(([^)\s]+)` — it stops at the first whitespace, captures `"A"`, and reports the figure **dangling while the file sits on disk beside it.**

**Measured: 0 of 3 references resolved before, 3 of 3 after.**

## The fix already existed in the codebase

The `pymupdf4llm` backend squeezes whitespace out of the stem for exactly this reason, with a comment saying so. The marker backend never got it. This applies the same `safe_stem`; `_finalize_assets` repoints the references off the directory name, so nothing else changes.

## Why not percent-encode or angle-bracket

Both are more standards-correct. Both are wrong **here**, because the consumer resolves a reference as a literal path with no URL-decoding:

| candidate | parses? | resolves? |
|---|---|---|
| `A Spaced Name_images/x.jpeg` | ✗ truncates to `A` | ✗ |
| `A%20Spaced%20Name_images/x.jpeg` | ✓ | ✗ — looks for a literal `%20` path |
| `<A Spaced Name_images/x.jpeg>` | ✗ captures `<A` | ✗ |
| `A_Spaced_Name_images/x.jpeg` | ✓ | ✓ |

Renaming the generated directory is the only fix that needs no consumer changed, and the name is generated rather than meaningful. Both rejected alternatives are **pinned as tests**, so the reasoning survives the next person who reaches for the standards-correct answer.

## Scope

Found while testing the Phase 5 pipeline, which converts whatever lands in the inbox and so meets scanner filenames with spaces routinely — `The Person and the Situation.pdf` is already in the archive.

It does **not** explain the corpus's existing 1025 dangling references: there are zero space-bearing refs among the filed sources. I checked that hypothesis and it was wrong.

**340 passed, 2 skipped.** The unspaced case is tested as byte-identical, so this cannot rename anything that works today.