### PR TITLE
Verify a scan's page numbers against its own page images

### DIFF
--- a/8-DECISIONS/2026-08-17-folio-verification.md
+++ b/8-DECISIONS/2026-08-17-folio-verification.md
@@ -78,6 +78,31 @@ that reads almost nothing and then reports no problem is worse than no check,
 because it is indistinguishable from a pass. "No shift found" and "no data" are
 different answers and get different exit codes.
 
+## Two ways to be confidently wrong, both found by review
+
+Independent review (codex) found that the first implementation could return either
+verdict falsely, which for a tool whose entire job is a verdict is the whole ballgame.
+Both are now regression tests.
+
+**False clean.** If OCR lifts a non-folio out of the band — `CHAPTER 4` on every
+page — every page reports the same number, so every page implies a *different*
+offset, so no segment forms, so no transition is found. The tool reported no shift
+and exited 0 without having read a single real folio. Read fraction cannot see
+this: the pages were read, they just said nothing. **A result is now conclusive
+only when some offset is ESTABLISHED** — supported by adjacent pages agreeing —
+and otherwise reports "no stable offset" and exits 2.
+
+**False anomaly.** Segments ignored index gaps entirely, so three pages agreeing at
+one offset on pages 10, 20 and 30 with everything between unread became an
+established run, and a transition was manufactured against a perfectly good book.
+That is the exact far-apart pattern this document already classified as noise, so
+the code contradicted its own spec. Segments now break across a gap larger than
+`MAX_SEGMENT_GAP`. Splitting a genuine segment costs nothing: two segments at the
+same offset yield no transition.
+
+The pair is the lesson. A verdict tool needs both failure directions tested, not
+just the one it was written to catch.
+
 ## Consequences
 
 - New optional dependency on `tesseract` for this tool only. `pytesseract` is used

--- a/8-DECISIONS/2026-08-17-folio-verification.md
+++ b/8-DECISIONS/2026-08-17-folio-verification.md
@@ -1,0 +1,88 @@
+---
+type: decision
+date: 2026-08-17
+status: accepted
+tags: [locators, quality, ocr, verification]
+---
+
+# A converted scan can prove its own page numbers
+
+## Decision
+
+Ship `verify_folios.py`: read the printed folio off every page image of a scanned
+PDF and report whether the book's pagination is coherent. Detect a shift as a
+**transition between two established offsets**, never as "the offset that is less
+common".
+
+The tool knows nothing about any corpus. It takes a PDF and reports what its pages
+say. Comparing that against a converted file's own markers belongs downstream, in
+whatever holds those files.
+
+## Why
+
+`convert.py` captures folios where it can and **interpolates** the rest from a
+consensus offset (`_OFFSET_CONSENSUS_MIN_AGREEMENT`, the consensus rule). That is
+correct behaviour: a folio hidden under a fold, inside a figure, or on a chapter
+opener should not leave a hole in the locator sequence.
+
+But it leaves the output part measured and part computed, with nothing afterwards
+able to tell the two apart. Coverage figures make this concrete — one book in the
+Management Craft corpus carries `page_printed_coverage: 0.095`. Nine in ten of its
+page numbers were never read off a page.
+
+Interpolation is sound exactly as far as the offset is. The failure it cannot
+survive is a **pagination shift**: an unnumbered plate section, a bound-in map, an
+inserted errata leaf. Every folio after it moves, one constant offset is applied
+over the top, and the result is smooth, self-consistent, and wrong from that point
+onward. A reader sent to page 214 finds page 206.
+
+The decisive property is that **interpolation does not merely fail to catch this —
+it smooths it.** The more thoroughly a file is interpolated, the more perfectly
+coherent a shifted book looks. So the check cannot be internal to the conversion.
+It has to go back to the images.
+
+## Why a transition, not a minority
+
+The first implementation asked which offset was most common and called everything
+else an anomaly. It inverts: put a plate section a third of the way into a book and
+the shifted region is the *majority*, so the tool indicts the correct pages and
+blesses the wrong ones.
+
+A pagination shift is not a minority. It is a change that persists. Two established
+runs — each long enough that OCR noise cannot fake one — meeting at different
+offsets is the signature, and it has no orientation. It does not care which side is
+bigger.
+
+This was caught by a test, not by review. `test_the_shift_is_caught_even_when_it_covers_MOST_of_the_book`
+is that case and stays as the regression.
+
+## Noise versus signal
+
+Real corpus behaviour, from four books read end to end:
+
+- **Noise** is scattered. Pages disagree individually, each implying its own
+  offset (-84, -192, -230 in one book). tesseract has picked a note number, a
+  figure callout, or a table value out of the margin band.
+- **A digit-confusion class** is still noise. One book read `81` as `31`, `85` as
+  `35`, `181` as `131` — same wrong offset three times, on pages far apart. An 8
+  misread as a 3 is not a shift.
+- **A shift** moves adjacent pages together and keeps them there.
+
+`MIN_ANOMALY_RUN = 3` is the floor. Two consecutive misreads happen — facing pages
+share a scan artifact — and three consecutive pages agreeing on a new offset do not.
+
+## Refusing to answer
+
+Below `MIN_READ_FRACTION` the tool reports **inconclusive** and exits 2. A check
+that reads almost nothing and then reports no problem is worse than no check,
+because it is indistinguishable from a pass. "No shift found" and "no data" are
+different answers and get different exit codes.
+
+## Consequences
+
+- New optional dependency on `tesseract` for this tool only. `pytesseract` is used
+  when present (`requirements-ocr.txt`); otherwise the binary is called directly.
+  Conversion is unaffected.
+- The analysis half is pure and directly testable, so the OCR half does not have to
+  run in tests.
+- Downstream consumers get a machine-readable verdict via `--json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,14 @@ The marginal cost of completeness is near zero with AI. Do the whole thing. Do i
 - The `clean_title()` function strips version markers (e.g., "V3") from filenames for cleaner titles
 - Inspect the `.report.json` sidecar to see what happened: `jq '.method,.extracted_assets,.quality_score' output/*.report.json`
 
+## Verifying a scan's page numbers
+
+`convert.py` reads printed folios where it can and **interpolates** the rest from a consensus offset. That leaves the output part measured and part computed, and nothing downstream can tell which is which. The failure it cannot survive is a **pagination shift** — an unnumbered plate section or bound-in map — because one constant offset is then applied over the top and every folio past it is smoothly, self-consistently wrong.
+
+`python verify_folios.py <pdf>` reads the folios back off the page images and reports it. Exit 0 no shift, 1 a shift (folios past it are suspect), **2 too few folios read to say anything — which is not a pass**. `--json` for a machine-readable verdict.
+
+A shift is detected as a **transition between two established offsets**, never as "the less common offset" — the latter inverts as soon as the shifted region is the larger one, and then the tool indicts the correct pages. See `8-DECISIONS/2026-08-17-folio-verification.md`.
+
 ## Post-Conversion Quality Check (REQUIRED)
 
 After every conversion run, automatically spot-check each converted file:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,40 @@ Conversion paths:
 - **OCR** (PDF): Tesseract OCR for scanned/image-based PDFs
 - **Pandoc** (EPUB): Preserves the epub's chapter structure as markdown headings
 
+## Verifying a scan's page numbers
+
+A scanned book's page numbers are part measurement and part arithmetic. `convert.py` reads
+the printed folio where it can and **interpolates** the rest from a consensus offset, which
+is the right call — a folio hidden under a fold should not leave a hole. But afterwards
+nothing tells you which numbers were read and which were computed, or whether the
+computation is right.
+
+The failure that matters is a **pagination shift**: an unnumbered plate section, a bound-in
+map, an inserted errata leaf. Every folio after it moves, and because one offset is applied
+across the whole book the output stays smooth, self-consistent, and wrong from that point
+on. A reader sent to page 214 finds page 206.
+
+`verify_folios.py` reads the folios back off the page images and reports whether the
+pagination is coherent:
+
+```bash
+python verify_folios.py input/book.pdf
+python verify_folios.py input/book.pdf --json folios.json   # machine-readable
+python verify_folios.py input/book.pdf --pages 0-99 --dpi 400
+```
+
+It distinguishes OCR noise from a real shift by shape, not by frequency: scattered pages
+disagreeing are misreads, while the offset *changing and holding* is a shift.
+
+| exit | meaning |
+|---|---|
+| 0 | no shift found |
+| 1 | the pagination shifts somewhere — folios past that point are suspect |
+| 2 | too few folios could be read to say anything. **Not a pass.** |
+
+Needs `tesseract` (`brew install tesseract`). `pytesseract` is used when installed
+(`requirements-ocr.txt`); otherwise the `tesseract` binary is called directly.
+
 ## Setup
 
 ### Default install (text-only extraction)

--- a/tests/test_verify_folios.py
+++ b/tests/test_verify_folios.py
@@ -175,3 +175,40 @@ def test_exit_codes_are_distinguishable():
     assert (clean["conclusive"], bool(clean["anomalies"])) == (True, False)
     assert (shifted["conclusive"], bool(shifted["anomalies"])) == (True, True)
     assert thin["conclusive"] is False
+
+
+# ── codex round 1, 2026-08-17: two verdicts that were confidently wrong ──────────────
+
+def test_a_misread_constant_is_not_a_clean_book():
+    """OCR lifts 'CHAPTER 4' out of the band on every page. Same number everywhere, so a
+    DIFFERENT offset on every page, so no segment, so no transition — and the tool used to
+    call that clean and exit 0 without having read one real folio. Read fraction cannot
+    see this; only the absence of an established offset can."""
+    r = analyse({i: 4 for i in range(20, 120)}, total_pages=140)
+    assert r["conclusive"] is False, "no stable offset must be inconclusive, never clean"
+    assert r["pages_in_established_runs"] == 0
+
+
+def test_far_apart_readings_do_not_form_a_run():
+    """Three pages agreeing at one offset with everything between them unread are three
+    coincidences, not a run. Chaining them manufactured a transition against a good book —
+    and contradicted this tool's own decision doc, which classes that pattern as noise."""
+    folios = {10: 3, 20: 13, 30: 23, **{i: i - 17 for i in range(40, 90)}}
+    r = analyse(folios, total_pages=140)
+    assert r["anomalies"] == []
+
+
+def test_a_small_gap_still_holds_a_segment_together():
+    """The other half: tesseract missing a few pages must not split a real book."""
+    folios = {i: i - 17 for i in range(20, 90) if i not in (40, 41, 42)}
+    r = analyse(folios, total_pages=140)
+    assert r["anomalies"] == []
+    assert r["conclusive"] is True
+
+
+def test_a_real_shift_survives_the_gap_rule():
+    """The gap rule must not have disarmed the detector it protects."""
+    folios = {**{i: i - 17 for i in range(20, 60)}, **{i: i - 25 for i in range(60, 110)}}
+    r = analyse(folios, total_pages=140)
+    assert len(r["anomalies"]) == 1
+    assert r["anomalies"][0]["shift"] == -8

--- a/tests/test_verify_folios.py
+++ b/tests/test_verify_folios.py
@@ -1,0 +1,177 @@
+"""Tests for verify_folios.
+
+The analysis half is pure, so it is tested directly against constructed folio maps. That
+matters more than an end-to-end OCR test here: the thing worth getting right is the
+distinction between OCR noise and a real pagination shift, and that distinction is a
+property of `analyse`, not of tesseract.
+
+Both halves are covered, per the rule that a filter is only verified when the bad case is
+gone AND the legitimate population still passes: a book with scattered misreads must come
+back CLEAN, and a book with an inserted plate section must come back ANOMALOUS.
+"""
+import pytest
+
+from verify_folios import MIN_ANOMALY_RUN, analyse, find_transitions, folio_from_text
+
+
+# ── reading a folio out of an OCR'd band ─────────────────────────────────────────────
+
+def test_folio_alone_on_its_line():
+    assert folio_from_text("214\n") == 214
+
+
+def test_folio_beside_a_running_head():
+    assert folio_from_text("214  The Knowing-Doing Gap\n") == 214
+    assert folio_from_text("The Knowing-Doing Gap  214\n") == 214
+
+
+def test_number_buried_mid_line_is_not_a_folio():
+    # A citation or a figure callout. Taking this would invent a page number.
+    assert folio_from_text("as Argyris showed in 1977 the gap persists\n") is None
+
+
+def test_empty_band():
+    assert folio_from_text("") is None
+    assert folio_from_text("\n\n  \n") is None
+
+
+def test_five_digit_number_is_not_a_folio():
+    assert folio_from_text("100000\n") is None
+
+
+# ── the clean case: a well-numbered book with OCR noise ──────────────────────────────
+
+def _clean_book(n=100, offset=-17):
+    return {i: i + offset for i in range(20, 20 + n)}
+
+
+def test_a_clean_book_reports_no_anomaly():
+    r = analyse(_clean_book(), total_pages=140)
+    assert r["dominant_offset"] == -17
+    assert r["anomalies"] == []
+    assert r["conclusive"] is True
+
+
+def test_scattered_misreads_are_noise_not_an_anomaly():
+    """The real shape from pfeffer-sutton: three pages misread, each differently."""
+    folios = _clean_book()
+    folios[40] = 2      # tesseract grabbed a note number
+    folios[86] = 2
+    folios[110] = 7
+    r = analyse(folios, total_pages=140)
+    assert len(r["disagreeing_pages"]) == 3
+    assert r["anomalies"] == [], "isolated misreads must not be called a pagination shift"
+
+
+def test_two_adjacent_misreads_are_still_noise():
+    """Facing pages share a scan artifact. The floor is MIN_ANOMALY_RUN."""
+    folios = _clean_book()
+    folios[50] = 999
+    folios[51] = 999
+    r = analyse(folios, total_pages=140)
+    assert r["anomalies"] == []
+
+
+def test_a_digit_confusion_class_does_not_trigger_an_anomaly():
+    """jay-the-defining-decade: an 8 read as a 3 on three NON-adjacent pages."""
+    folios = _clean_book()
+    for p, wrong in ((60, 60 - 17 - 50), (64, 64 - 17 - 50), (160 - 60, 100 - 17 - 50)):
+        folios[p] = wrong
+    r = analyse(folios, total_pages=140)
+    assert r["anomalies"] == [], "same wrong offset, but not adjacent — still noise"
+
+
+# ── the case the tool exists for ─────────────────────────────────────────────────────
+
+def test_an_inserted_plate_section_is_caught():
+    """Eight unnumbered plate pages bound in at page 60. Every folio after shifts by 8,
+    and interpolation from one constant offset would render all of them smoothly wrong."""
+    folios = {}
+    for i in range(20, 60):
+        folios[i] = i - 17
+    for i in range(60, 120):
+        folios[i] = i - 17 - 8
+    r = analyse(folios, total_pages=140)
+    assert len(r["anomalies"]) == 1
+    a = r["anomalies"][0]
+    assert a["last_page_before"] == 59
+    assert a["first_page_after"] == 60
+    assert (a["from_offset"], a["to_offset"]) == (-17, -25)
+    assert a["shift"] == -8
+
+
+def test_the_shift_is_caught_even_when_it_covers_MOST_of_the_book():
+    """The regression that killed the first design. Detecting the anomaly as "the offset
+    that is not most common" inverts here: the shifted region is larger, so the GOOD pages
+    became the anomaly. A transition has no such orientation."""
+    folios = {**{i: i - 17 for i in range(20, 40)}, **{i: i - 25 for i in range(40, 130)}}
+    r = analyse(folios, total_pages=140)
+    assert len(r["anomalies"]) == 1
+    assert (r["anomalies"][0]["from_offset"], r["anomalies"][0]["to_offset"]) == (-17, -25)
+
+
+def test_a_gap_of_unread_pages_does_not_split_a_segment():
+    """Pages tesseract could not read are absent, not a boundary."""
+    folios = {i: i - 17 for i in range(20, 60) if i not in (33, 34, 47)}
+    r = analyse(folios, total_pages=80)
+    assert r["anomalies"] == []
+
+
+def test_alternating_misreads_are_not_a_transition():
+    offsets = {10: -17, 11: -25, 12: -17, 13: -25, 14: -17}
+    assert find_transitions(offsets) == []
+
+
+def test_exactly_the_minimum_run_counts():
+    folios = _clean_book()
+    for i in range(70, 70 + MIN_ANOMALY_RUN):
+        folios[i] = i - 17 - 9
+    r = analyse(folios, total_pages=140)
+    # In and out again: two transitions, -17 -> -26 and -26 -> -17.
+    assert len(r["anomalies"]) == 2
+    assert r["anomalies"][0]["shift"] == -9
+
+
+def test_one_short_of_the_minimum_does_not():
+    folios = _clean_book()
+    for i in range(70, 70 + MIN_ANOMALY_RUN - 1):
+        folios[i] = i - 17 - 9
+    r = analyse(folios, total_pages=140)
+    assert r["anomalies"] == []
+
+
+# ── refusing to answer ───────────────────────────────────────────────────────────────
+
+def test_too_few_folios_is_inconclusive_not_clean():
+    """A check that reads almost nothing and reports no anomaly looks exactly like a
+    pass. It must not be one."""
+    r = analyse({20: 3, 21: 4}, total_pages=400)
+    assert r["conclusive"] is False
+    assert r["anomalies"] == []
+
+
+def test_no_folios_at_all():
+    r = analyse({}, total_pages=100)
+    assert r["conclusive"] is False
+    assert r["dominant_offset"] is None
+
+
+def test_zero_pages_does_not_divide_by_zero():
+    r = analyse({}, total_pages=0)
+    assert r["read_fraction"] == 0.0
+
+
+# ── the CLI contract ─────────────────────────────────────────────────────────────────
+
+def test_exit_codes_are_distinguishable():
+    """0 clean, 1 anomaly, 2 cannot say — a caller must be able to tell 'no problem'
+    from 'no data'."""
+    clean = analyse(_clean_book(), total_pages=140)
+    shifted = analyse(
+        {**{i: i - 17 for i in range(20, 60)}, **{i: i - 30 for i in range(60, 120)}},
+        total_pages=140,
+    )
+    thin = analyse({20: 3}, total_pages=400)
+    assert (clean["conclusive"], bool(clean["anomalies"])) == (True, False)
+    assert (shifted["conclusive"], bool(shifted["anomalies"])) == (True, True)
+    assert thin["conclusive"] is False

--- a/verify_folios.py
+++ b/verify_folios.py
@@ -73,6 +73,14 @@ MIN_ANOMALY_RUN = 3
 # reports no anomaly is worse than no check, because it looks like a pass.
 MIN_READ_FRACTION = 0.25
 
+# How many unread pages a single segment may span before its readings stop counting as
+# evidence about each other. A shift is physical: the pages it moves are contiguous. Three
+# readings agreeing at one offset on pages 10, 20 and 30 with everything between unread are
+# not a run, they are three coincidences — and treating them as a run manufactures a
+# transition against a perfectly good book (codex, 2026-08-17). Splitting a GENUINE segment
+# by this rule is harmless: two segments at the same offset yield no transition.
+MAX_SEGMENT_GAP = 5
+
 
 def _ocr(png_path: str) -> str:
     """OCR one band image. Prefers pytesseract (requirements-ocr.txt), falls back to the
@@ -157,12 +165,16 @@ def read_folios(pdf: str, dpi: int = 300, band: float = 0.11,
 def segments(offsets: dict[int, int]) -> list[list[int]]:
     """The read pages, in order, grouped into maximal runs that share one offset.
 
-    Index gaps are allowed inside a segment: pages whose margins yielded nothing are
-    simply absent, and a book does not become two books because tesseract missed page 84.
+    Small index gaps are allowed inside a segment — pages whose margins yielded nothing
+    are simply absent, and a book does not become two books because tesseract missed page
+    84. Gaps larger than MAX_SEGMENT_GAP do break the segment, because past that distance
+    the readings are no longer evidence about each other.
     """
     out: list[list[int]] = []
     for i in sorted(offsets):
-        if out and offsets[out[-1][-1]] == offsets[i]:
+        same_offset = out and offsets[out[-1][-1]] == offsets[i]
+        near = out and (i - out[-1][-1]) <= MAX_SEGMENT_GAP
+        if same_offset and near:
             out[-1].append(i)
         else:
             out.append([i])
@@ -209,6 +221,13 @@ def analyse(folios: dict[int, int], total_pages: int) -> dict:
     disagreeing = sorted(i for i, o in offsets.items() if o != dominant)
     anomalies = find_transitions(offsets)
     read_fraction = len(folios) / total_pages if total_pages else 0.0
+    # An offset is ESTABLISHED when adjacent pages agree on it. Without at least one, the
+    # readings are noise however many there are — the failure case is OCR grabbing a
+    # non-folio like "CHAPTER 4" off every page, which yields a different offset per page,
+    # no segment at all, no transitions, and therefore a confident exit 0 without a single
+    # real folio having been read (codex, 2026-08-17). Read fraction alone cannot see that.
+    established = [s for s in segments(offsets) if len(s) >= MIN_ANOMALY_RUN]
+    supported = sum(len(s) for s in established)
     return {
         "pages": total_pages,
         "folios_read": len(folios),
@@ -217,7 +236,8 @@ def analyse(folios: dict[int, int], total_pages: int) -> dict:
         "pages_at_dominant_offset": dominant_n,
         "disagreeing_pages": disagreeing,
         "anomalies": anomalies,
-        "conclusive": read_fraction >= MIN_READ_FRACTION,
+        "pages_in_established_runs": supported,
+        "conclusive": read_fraction >= MIN_READ_FRACTION and bool(established),
     }
 
 
@@ -227,10 +247,17 @@ def render(result: dict) -> str:
         f"({result['read_fraction']:.1%})",
     ]
     if not result["conclusive"]:
-        out.append(
-            f"  TOO FEW FOLIOS READ to draw a conclusion (floor is {MIN_READ_FRACTION:.0%}).\n"
-            f"  This is not a pass. Try --dpi 400, or a wider --band, or the scan is unnumbered."
-        )
+        if result["read_fraction"] < MIN_READ_FRACTION:
+            out.append(
+                f"  TOO FEW FOLIOS READ to draw a conclusion (floor is {MIN_READ_FRACTION:.0%}).\n"
+                f"  This is not a pass. Try --dpi 400, or a wider --band, or the scan is unnumbered."
+            )
+        else:
+            out.append(
+                "  NO STABLE OFFSET. Folios were read, but no run of adjacent pages agrees on\n"
+                "  one offset — the signature of OCR lifting a non-folio (a chapter number, a\n"
+                "  figure label) out of the margin band. This is not a pass. Try --band or --dpi."
+            )
         return "\n".join(out)
     out.append(
         f"  dominant offset {result['dominant_offset']:+d} "
@@ -294,8 +321,10 @@ def main() -> int:
 
     folios = read_folios(args.pdf, dpi=args.dpi, band=args.band,
                          pages=args.pages, progress=progress)
-    scanned = len(args.pages) if args.pages else total
-    result = analyse(folios, min(scanned, total))
+    # Intersect the requested range with the document, or a range running past EOF makes
+    # the denominator too large and turns a good read into a spurious "inconclusive".
+    scanned = len([i for i in args.pages if i < total]) if args.pages else total
+    result = analyse(folios, scanned)
     result["pdf"] = os.path.basename(args.pdf)
     result["folios"] = {str(k): v for k, v in sorted(folios.items())}
 

--- a/verify_folios.py
+++ b/verify_folios.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Verify a scanned PDF's printed page numbers by reading them off the page images.
+
+WHY THIS EXISTS
+
+convert.py already captures printed folios from a scan and, where it cannot read one,
+INTERPOLATES it from a consensus offset. That is the right behaviour — a folio missed
+because it sits under a fold or inside a figure should not leave a hole. But it means a
+converted book's page numbers are part measurement and part arithmetic, and nothing
+afterwards can tell you which is which, or whether the arithmetic is right.
+
+The failure that matters is not a misread digit. It is a PAGINATION ANOMALY: an
+unnumbered plate section, an inserted errata leaf, a bound-in map. Every folio after it
+shifts, and because interpolation applies one constant offset across the whole book, the
+output is smooth, self-consistent, and wrong from that point on. A reader sent to page 214
+finds page 206.
+
+Interpolation cannot surface that. It smooths it. So this reads the folios back off the
+page images and looks for the one signature that distinguishes a real shift from OCR
+noise:
+
+    NOISE     scattered pages disagreeing, each implying its own offset
+    SHIFT     the offset CHANGES at some page and HOLDS there
+
+A single page reading 31 where the book says 81 is tesseract misreading an 8. Twenty
+consecutive pages all reading exactly 8 less is a plate section.
+
+Note the shape of that test. An earlier version asked "which offset is not the most
+common one", and it inverts the moment the shifted region is larger than the correct one:
+a plate section a third of the way into a book makes the GOOD pages the minority, and the
+tool indicts them. A transition between two established runs has no such orientation. It
+does not care which side is bigger.
+
+WHAT IT DOES NOT DO
+
+It knows nothing about your corpus, your frontmatter, or where you file things. It takes
+a PDF and reports what its pages say. Comparing that against a converted file's own
+markers is a job for whatever holds those files.
+
+USAGE
+    python verify_folios.py book.pdf
+    python verify_folios.py book.pdf --json report.json
+    python verify_folios.py book.pdf --pages 0-99 --dpi 400
+
+EXIT
+    0  no shift found
+    1  the pagination shifts somewhere (the offset changes and stays changed)
+    2  too few folios could be read to say anything — NOT a pass
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+
+# A folio standing alone. Four digits max, so a year printed in a running head is
+# admitted here and rejected later by the offset check, rather than being silently
+# reinterpreted as a page number.
+_STANDALONE = re.compile(r"^\d{1,4}$")
+_EDGE = re.compile(r"^(\d{1,4})\b|\b(\d{1,4})$")
+
+# An adjacent run must reach this length before it is called an anomaly rather than
+# noise. Two consecutive misreads are common (facing pages share a scan artifact);
+# three consecutive pages agreeing on a NEW offset is not a coincidence.
+MIN_ANOMALY_RUN = 3
+
+# Below this, the report is "cannot say", never "clean". A check that reads nothing and
+# reports no anomaly is worse than no check, because it looks like a pass.
+MIN_READ_FRACTION = 0.25
+
+
+def _ocr(png_path: str) -> str:
+    """OCR one band image. Prefers pytesseract (requirements-ocr.txt), falls back to the
+    tesseract binary so the tool still runs where only the CLI is installed."""
+    try:
+        import pytesseract
+        from PIL import Image
+
+        return pytesseract.image_to_string(Image.open(png_path), config="--psm 6")
+    except ImportError:
+        pass
+    try:
+        out = subprocess.run(
+            ["tesseract", png_path, "stdout", "--psm", "6"],
+            capture_output=True, text=True, timeout=60,
+        )
+        return out.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ""
+
+
+def folio_from_text(text: str) -> int | None:
+    """The folio off one OCR'd margin band.
+
+    A number ALONE on its line is the folio. Otherwise a number at the very start or end
+    of a line, which is the running-head-plus-folio case ("214  The Knowing-Doing Gap").
+    A number in the middle of a line is prose or a citation, and is ignored.
+    """
+    lines = [ln.strip() for ln in text.split("\n") if ln.strip()]
+    for ln in lines:
+        if _STANDALONE.match(ln):
+            return int(ln)
+    for ln in lines:
+        m = _EDGE.search(ln)
+        if m:
+            return int(m.group(1) or m.group(2))
+    return None
+
+
+def read_folios(pdf: str, dpi: int = 300, band: float = 0.11,
+                pages: range | None = None, progress=None) -> dict[int, int]:
+    """{page index (0-based) -> folio read off that page's margin}.
+
+    Both margins are tried because books put the folio at the head or the foot, and a
+    single book does both (chapter openers drop to the foot). Pages whose margins yield
+    no number are simply absent from the result.
+    """
+    import fitz  # PyMuPDF, a core requirement
+
+    doc = fitz.open(pdf)
+    try:
+        idxs = pages if pages is not None else range(doc.page_count)
+        found: dict[int, int] = {}
+        for i in idxs:
+            if i >= doc.page_count:
+                break
+            page = doc[i]
+            r = page.rect
+            h = band * r.height
+            for clip in (
+                fitz.Rect(r.x0, r.y0, r.x1, r.y0 + h),
+                fitz.Rect(r.x0, r.y1 - h, r.x1, r.y1),
+            ):
+                pix = page.get_pixmap(dpi=dpi, clip=clip)
+                with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+                    fh.write(pix.tobytes("png"))
+                    tmp = fh.name
+                try:
+                    got = folio_from_text(_ocr(tmp))
+                finally:
+                    os.unlink(tmp)
+                if got is not None:
+                    found[i] = got
+                    break
+            if progress:
+                progress(i)
+        return found
+    finally:
+        doc.close()
+
+
+def segments(offsets: dict[int, int]) -> list[list[int]]:
+    """The read pages, in order, grouped into maximal runs that share one offset.
+
+    Index gaps are allowed inside a segment: pages whose margins yielded nothing are
+    simply absent, and a book does not become two books because tesseract missed page 84.
+    """
+    out: list[list[int]] = []
+    for i in sorted(offsets):
+        if out and offsets[out[-1][-1]] == offsets[i]:
+            out[-1].append(i)
+        else:
+            out.append([i])
+    return out
+
+
+def find_transitions(offsets: dict[int, int]) -> list[dict]:
+    """Points where the offset CHANGES and stays changed.
+
+    Detecting a shift by "which offset is not the most common one" is fragile: it inverts
+    as soon as the shifted region is larger than the correct one, and then the anomaly is
+    reported against the good pages. A plate section bound in at page 60 of a 140-page
+    book does exactly that.
+
+    A pagination shift is not a minority, it is a TRANSITION — the offset changes at some
+    page and holds. So the signature is two ESTABLISHED segments (each at least
+    MIN_ANOMALY_RUN pages, which noise cannot reach) meeting at different offsets. Short
+    segments between them are misreads and are stepped over, not treated as boundaries.
+    """
+    established = [s for s in segments(offsets) if len(s) >= MIN_ANOMALY_RUN]
+    out: list[dict] = []
+    for prev, nxt in zip(established, established[1:]):
+        a, b = offsets[prev[-1]], offsets[nxt[0]]
+        if a == b:
+            continue
+        out.append({
+            "from_offset": a,
+            "to_offset": b,
+            "last_page_before": prev[-1],
+            "first_page_after": nxt[0],
+            "shift": b - a,
+            "length": len(nxt),
+            "folios": [offsets[i] + i for i in nxt[:6]],
+        })
+    return out
+
+
+def analyse(folios: dict[int, int], total_pages: int) -> dict:
+    """Turn read folios into a verdict. Pure — no I/O, so it is directly testable."""
+    offsets = {i: f - i for i, f in folios.items()}
+    counts = Counter(offsets.values())
+    dominant, dominant_n = counts.most_common(1)[0] if counts else (None, 0)
+
+    disagreeing = sorted(i for i, o in offsets.items() if o != dominant)
+    anomalies = find_transitions(offsets)
+    read_fraction = len(folios) / total_pages if total_pages else 0.0
+    return {
+        "pages": total_pages,
+        "folios_read": len(folios),
+        "read_fraction": round(read_fraction, 4),
+        "dominant_offset": dominant,
+        "pages_at_dominant_offset": dominant_n,
+        "disagreeing_pages": disagreeing,
+        "anomalies": anomalies,
+        "conclusive": read_fraction >= MIN_READ_FRACTION,
+    }
+
+
+def render(result: dict) -> str:
+    out = [
+        f"pages {result['pages']}, folios read {result['folios_read']} "
+        f"({result['read_fraction']:.1%})",
+    ]
+    if not result["conclusive"]:
+        out.append(
+            f"  TOO FEW FOLIOS READ to draw a conclusion (floor is {MIN_READ_FRACTION:.0%}).\n"
+            f"  This is not a pass. Try --dpi 400, or a wider --band, or the scan is unnumbered."
+        )
+        return "\n".join(out)
+    out.append(
+        f"  dominant offset {result['dominant_offset']:+d} "
+        f"on {result['pages_at_dominant_offset']} pages"
+    )
+    out.append(f"  pages disagreeing: {len(result['disagreeing_pages'])}")
+    if not result["anomalies"]:
+        out.append(
+            "  NO PAGINATION ANOMALY. Every disagreement is isolated, which is the OCR-noise\n"
+            "  signature; a real shift moves a run of adjacent pages together."
+        )
+    else:
+        out.append(f"  {len(result['anomalies'])} PAGINATION SHIFT(S) — the offset changes and stays changed:")
+        for a in result["anomalies"]:
+            out.append(
+                f"      between page {a['last_page_before']} and page {a['first_page_after']}: "
+                f"offset {a['from_offset']:+d} -> {a['to_offset']:+d} "
+                f"(a shift of {a['shift']:+d}), holding for {a['length']} read pages"
+            )
+        out.append(
+            "  Interpolated folios past the first shift are suspect. A reader sent to a page\n"
+            "  beyond it lands somewhere else."
+        )
+    return "\n".join(out)
+
+
+def _parse_pages(spec: str) -> range:
+    m = re.fullmatch(r"(\d+)-(\d+)", spec)
+    if not m:
+        raise argparse.ArgumentTypeError("--pages wants a range like 0-99")
+    return range(int(m.group(1)), int(m.group(2)) + 1)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Read a scanned PDF's printed page numbers off the page images and "
+                    "report whether its pagination is coherent.",
+    )
+    ap.add_argument("pdf")
+    ap.add_argument("--dpi", type=int, default=300)
+    ap.add_argument("--band", type=float, default=0.11,
+                    help="fraction of page height treated as the margin band (default 0.11)")
+    ap.add_argument("--pages", type=_parse_pages, default=None, help="e.g. 0-99")
+    ap.add_argument("--json", dest="json_out", default=None)
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.pdf):
+        print(f"verify_folios: no such file: {args.pdf}", file=sys.stderr)
+        return 2
+
+    import fitz
+
+    doc = fitz.open(args.pdf)
+    total = doc.page_count
+    doc.close()
+
+    def progress(i):
+        if not args.quiet and i % 25 == 0:
+            print(f"  ... page {i}", file=sys.stderr, flush=True)
+
+    folios = read_folios(args.pdf, dpi=args.dpi, band=args.band,
+                         pages=args.pages, progress=progress)
+    scanned = len(args.pages) if args.pages else total
+    result = analyse(folios, min(scanned, total))
+    result["pdf"] = os.path.basename(args.pdf)
+    result["folios"] = {str(k): v for k, v in sorted(folios.items())}
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+    if not args.quiet:
+        print(render(result))
+
+    if not result["conclusive"]:
+        return 2
+    return 1 if result["anomalies"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

`verify_folios.py` — read the printed folio off every page image of a scanned PDF and report whether the book's pagination is coherent.

## Why

`convert.py` reads printed folios where it can and **interpolates** the rest from a consensus offset. That is the right call: a folio hidden under a fold, inside a figure, or on a chapter opener should not leave a hole in the locator sequence.

But it leaves the output part measured and part computed, with nothing afterwards able to tell the two apart. One book in a corpus using this converter carries `page_printed_coverage: 0.095` — nine in ten of its page numbers were never read off a page.

The failure interpolation cannot survive is a **pagination shift**: an unnumbered plate section, a bound-in map, an inserted errata leaf. Every folio after it moves, one constant offset goes over the top, and the result is smooth, self-consistent and wrong from that point on. A reader sent to page 214 finds page 206.

The decisive part is that **interpolation does not merely fail to catch this — it smooths it.** The more thoroughly a file is interpolated, the more perfectly coherent a shifted book looks. So the check cannot live inside the conversion. It has to go back to the images.

## Design: a transition, not a minority

A shift is detected as a **transition between two established offsets**, never as "the offset that is not most common."

The first implementation did the latter, and it inverts: put a plate section a third of the way into a book and the shifted region is the *majority*, so the tool indicts the correct pages and blesses the wrong ones. A transition has no orientation — it does not care which side is bigger. Caught by a test, not by review; `test_the_shift_is_caught_even_when_it_covers_MOST_of_the_book` stays as the regression.

## Noise vs signal

From four books read end to end:

- **Noise** is scattered — pages disagree individually, each implying its own offset (−84, −192, −230 in one book). tesseract picked a note number or a table value out of the band.
- **A digit-confusion class is still noise.** One book read `81` as `31`, `85` as `35`, `181` as `131` — same wrong offset three times, pages far apart. An 8 misread as a 3 is not a shift.
- **A shift** moves adjacent pages together and keeps them there.

## Second commit: both verdicts could be false

Independent review found the first commit could return either verdict wrongly. Both are now regression tests.

- **False clean** — OCR lifting `CHAPTER 4` off every page gives the same number everywhere, so a different offset per page, so no segment, so no transition, so exit 0 without one real folio read. A result is now conclusive only when an offset is *established* by adjacent pages agreeing.
- **False anomaly** — segments ignored index gaps, so three agreeing pages at 10, 20 and 30 became a run and manufactured a shift against a good book. That is the far-apart pattern the decision doc already called noise, so the code contradicted its own spec.

## Exit codes

| exit | meaning |
|---|---|
| 0 | no shift found |
| 1 | the pagination shifts — folios past that point are suspect |
| 2 | too few folios read, or no stable offset. **Not a pass.** |

## Validation

Real scans, matching an analysis done independently by hand:

| book | folios read | dominant offset | shifts |
|---|---|---|---|
| The Knowing-Doing Gap | 308/338 (91.1%) | −17 | 0 |
| The Defining Decade | 261/332 (78.6%) | −31 | 0 |
| The Tao of Motivation | 126/158 (79.8%) | −9 | 0 |
| Bloom, Two Sigma | 14/15 (93.3%) | +3 | 0 |

## Notes

- `tesseract` is needed for this tool only; conversion is unaffected. `pytesseract` is used when installed, otherwise the binary is called directly.
- The analysis half is pure, so the OCR half does not have to run in tests.
- 23 tests. Full suite 373 passed.
- Docs: README, CLAUDE.md, `8-DECISIONS/2026-08-17-folio-verification.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)