### PR TITLE
Widen the margin band before reporting inconclusive

### DIFF
--- a/8-DECISIONS/2026-08-17-folio-verification.md
+++ b/8-DECISIONS/2026-08-17-folio-verification.md
@@ -103,6 +103,29 @@ same offset yield no transition.
 The pair is the lesson. A verdict tool needs both failure directions tested, not
 just the one it was written to catch.
 
+## Widening the band before giving up
+
+"Inconclusive" is the honest answer when the folios cannot be read, but it is only
+useful if it means *the book cannot be verified* rather than *the band was wrong*.
+
+`marrow-behind-the-executive-mask` is the case that separated those. At the default
+band it read 41 of 146 folios and reported inconclusive. Raising the DPI to 400
+changed nothing — 47 of 146 — because resolution was never the problem. Rendering a
+page and **looking at it** showed why: the folio sits at the end of the running head,
+"The Second Week: Emphasis on the Group • 101", about 13% down the page, and the
+band was the top 11%. It was cutting the folio off. At 0.17 the same scan yields 126
+folios at a constant offset of +1, matching the filed value exactly.
+
+So the tool now retries at wider bands when a pass cannot conclude. Widening runs
+only after an inconclusive result, so it can never turn one verdict into another —
+only "cannot say" into an answer. The band that produced a verdict is reported with
+it, because two runs of the same book can now read different numbers of folios and a
+result nobody can reproduce is not evidence.
+
+The general lesson is worth keeping: a diagnostic's own default can be the thing
+producing the null result, and no amount of turning the obvious knob (DPI) will show
+that. Looking at the artifact did.
+
 ## Consequences
 
 - New optional dependency on `tesseract` for this tool only. `pytesseract` is used

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ The marginal cost of completeness is near zero with AI. Do the whole thing. Do i
 
 `python verify_folios.py <pdf>` reads the folios back off the page images and reports it. Exit 0 no shift, 1 a shift (folios past it are suspect), **2 too few folios read to say anything — which is not a pass**. `--json` for a machine-readable verdict.
 
+If the first pass cannot conclude it retries at a wider margin band (`--no-widen` to disable), because the common cause of "inconclusive" is a running head set lower than the default band rather than anything wrong with the book. Raising `--dpi` does not help that; widening does.
+
 A shift is detected as a **transition between two established offsets**, never as "the less common offset" — the latter inverts as soon as the shifted region is the larger one, and then the tool indicts the correct pages. See `8-DECISIONS/2026-08-17-folio-verification.md`.
 
 ## Post-Conversion Quality Check (REQUIRED)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ python verify_folios.py input/book.pdf --pages 0-99 --dpi 400
 It distinguishes OCR noise from a real shift by shape, not by frequency: scattered pages
 disagreeing are misreads, while the offset *changing and holding* is a shift.
 
+If the first pass cannot conclude, the tool **retries at a wider margin band** before giving up. The default band assumes the folio sits in the outer margin; a running head set lower falls outside it, and the result is a useless "inconclusive" on a book whose folios are perfectly legible. `--no-widen` disables the retry. The band that produced a verdict is printed with it, so a result can be reproduced.
+
 | exit | meaning |
 |---|---|
 | 0 | no shift found |

--- a/tests/test_verify_folios.py
+++ b/tests/test_verify_folios.py
@@ -9,6 +9,9 @@ Both halves are covered, per the rule that a filter is only verified when the ba
 gone AND the legitimate population still passes: a book with scattered misreads must come
 back CLEAN, and a book with an inserted plate section must come back ANOMALOUS.
 """
+import json
+import sys
+
 import pytest
 
 from verify_folios import MIN_ANOMALY_RUN, analyse, find_transitions, folio_from_text
@@ -212,3 +215,100 @@ def test_a_real_shift_survives_the_gap_rule():
     r = analyse(folios, total_pages=140)
     assert len(r["anomalies"]) == 1
     assert r["anomalies"][0]["shift"] == -8
+
+
+# ── widening the band when the first pass cannot conclude ────────────────────────────
+
+def test_wider_bands_are_ordered_and_above_the_default():
+    from verify_folios import WIDER_BANDS
+    assert list(WIDER_BANDS) == sorted(WIDER_BANDS)
+    assert all(b > 0.11 for b in WIDER_BANDS), "a retry narrower than the default cannot help"
+
+
+def test_the_band_is_reported_so_a_verdict_can_be_reproduced():
+    """Two runs of the same book can now read different numbers of folios depending on the
+    band that succeeded. A verdict that does not say which band produced it cannot be
+    checked by anyone."""
+    from verify_folios import render
+    r = analyse(_clean_book(), total_pages=140)
+    r["band"] = 0.17
+    assert "margin band 0.17" in render(r)
+
+
+def test_widening_cannot_change_a_conclusive_verdict():
+    """The loop breaks on the first conclusive result, so a book that concludes at the
+    default band is never re-read at a wider one. Asserted on the predicate the loop uses,
+    because the loop itself needs a PDF."""
+    conclusive = analyse(_clean_book(), total_pages=140)
+    assert conclusive["conclusive"] is True
+    # A real shift must still be visible at the first band, not masked by a later retry.
+    shifted = analyse(
+        {**{i: i - 17 for i in range(20, 60)}, **{i: i - 25 for i in range(60, 110)}},
+        total_pages=140,
+    )
+    assert shifted["conclusive"] is True and len(shifted["anomalies"]) == 1
+
+
+def _fake_fitz(pages):
+    """A stand-in for PyMuPDF. main() opens the document only to count its pages."""
+    import types
+    doc = types.SimpleNamespace(page_count=pages, close=lambda: None)
+    return types.SimpleNamespace(open=lambda *a, **k: doc)
+
+
+def test_main_actually_retries_at_a_wider_band(tmp_path, monkeypatch, capsys):
+    """Drive the real loop in main().
+
+    The first attempt at this feature was a silent no-op: the patch that added the loop
+    failed to apply, so `--no-widen` existed and did nothing while the constants and the
+    render line were both present and tested. Every test passed. Nothing exercised main().
+
+    A test that cannot observe the behaviour it names is not a test of it — so this one
+    stubs read_folios per band and asserts the narrow band's answer is NOT what comes out.
+    """
+    import verify_folios as vf
+
+    calls = []
+
+    def fake_read_folios(pdf, dpi=300, band=0.11, pages=None, progress=None):
+        calls.append(band)
+        if band < 0.15:
+            return {i: 4 for i in range(0, 30)}          # no stable offset -> inconclusive
+        return {i: i - 17 for i in range(0, 100)}         # legible at the wider band
+
+    # fitz is imported INSIDE the functions, so the module object is what gets stubbed.
+    monkeypatch.setattr(vf, "read_folios", fake_read_folios)
+    monkeypatch.setitem(sys.modules, "fitz", _fake_fitz(140))
+    pdf = tmp_path / "book.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    out = tmp_path / "r.json"
+    monkeypatch.setattr(sys, "argv", ["verify_folios.py", str(pdf), "--quiet", "--json", str(out)])
+
+    rc = vf.main()
+    assert len(calls) > 1, "main() never retried — the widening loop is a no-op"
+    assert calls[0] < calls[1], "the retry must be WIDER than the first attempt"
+    assert rc == 0
+    result = json.loads(out.read_text())
+    assert result["conclusive"] is True
+    assert result["band"] == calls[-1]
+
+
+def test_no_widen_really_disables_the_retry(tmp_path, monkeypatch):
+    """A flag that does nothing is worse than no flag: it sends the operator to change
+    something that cannot help, and the tool keeps failing for the reason they just fixed."""
+    import verify_folios as vf
+
+    calls = []
+
+    def fake_read_folios(pdf, dpi=300, band=0.11, pages=None, progress=None):
+        calls.append(band)
+        return {i: 4 for i in range(0, 30)}
+
+    monkeypatch.setattr(vf, "read_folios", fake_read_folios)
+    monkeypatch.setitem(sys.modules, "fitz", _fake_fitz(140))
+    pdf = tmp_path / "book.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    monkeypatch.setattr(sys, "argv", ["verify_folios.py", str(pdf), "--quiet", "--no-widen"])
+
+    assert vf.main() == 2
+    assert calls == [0.11], "--no-widen must leave exactly one attempt"

--- a/verify_folios.py
+++ b/verify_folios.py
@@ -73,6 +73,20 @@ MIN_ANOMALY_RUN = 3
 # reports no anomaly is worse than no check, because it looks like a pass.
 MIN_READ_FRACTION = 0.25
 
+# Bands to try, in order, when the first pass cannot conclude. The default 0.11 is tuned to
+# a folio sitting in the outer margin; a running head set lower falls outside it and the
+# tool reports "inconclusive" on a book whose folios are perfectly legible.
+#
+# marrow-behind-the-executive-mask is the case. Its folio sits at the END of the running
+# head ("The Second Week: Emphasis on the Group  •  101"), about 13% down the page. At 0.11
+# the band cut it off and only 41 of 146 folios were read; the answer was "inconclusive",
+# which is honest but useless. Raising the DPI to 400 changed nothing, because resolution
+# was never the problem. At 0.17 the same scan yields 126 folios and a constant offset.
+#
+# Widening only ever runs when the pass BEFORE it could not conclude, so it cannot turn a
+# real verdict into a different one — only "cannot say" into an answer.
+WIDER_BANDS = (0.17, 0.24)
+
 # How many unread pages a single segment may span before its readings stop counting as
 # evidence about each other. A shift is physical: the pages it moves are contiguous. Three
 # readings agreeing at one offset on pages 10, 20 and 30 with everything between unread are
@@ -244,7 +258,8 @@ def analyse(folios: dict[int, int], total_pages: int) -> dict:
 def render(result: dict) -> str:
     out = [
         f"pages {result['pages']}, folios read {result['folios_read']} "
-        f"({result['read_fraction']:.1%})",
+        f"({result['read_fraction']:.1%})"
+        + (f", margin band {result['band']}" if result.get("band") else ""),
     ]
     if not result["conclusive"]:
         if result["read_fraction"] < MIN_READ_FRACTION:
@@ -256,7 +271,8 @@ def render(result: dict) -> str:
             out.append(
                 "  NO STABLE OFFSET. Folios were read, but no run of adjacent pages agrees on\n"
                 "  one offset — the signature of OCR lifting a non-folio (a chapter number, a\n"
-                "  figure label) out of the margin band. This is not a pass. Try --band or --dpi."
+                "  figure label) out of the margin band. This is not a pass. Wider bands were\n"
+                "  already tried; the folio may sit inside the text block, or there may be none."
             )
         return "\n".join(out)
     out.append(
@@ -302,6 +318,8 @@ def main() -> int:
                     help="fraction of page height treated as the margin band (default 0.11)")
     ap.add_argument("--pages", type=_parse_pages, default=None, help="e.g. 0-99")
     ap.add_argument("--json", dest="json_out", default=None)
+    ap.add_argument("--no-widen", action="store_true",
+                    help="do not retry at a wider margin band when the result is inconclusive")
     ap.add_argument("--quiet", action="store_true")
     args = ap.parse_args()
 
@@ -319,12 +337,28 @@ def main() -> int:
         if not args.quiet and i % 25 == 0:
             print(f"  ... page {i}", file=sys.stderr, flush=True)
 
-    folios = read_folios(args.pdf, dpi=args.dpi, band=args.band,
-                         pages=args.pages, progress=progress)
     # Intersect the requested range with the document, or a range running past EOF makes
     # the denominator too large and turns a good read into a spurious "inconclusive".
     scanned = len([i for i in args.pages if i < total]) if args.pages else total
-    result = analyse(folios, scanned)
+
+    # Widen the band and retry when a pass cannot conclude. See WIDER_BANDS: the common
+    # cause of "inconclusive" is a running head set lower than the default band, not
+    # anything wrong with the book, and raising the DPI does not touch it.
+    bands = [args.band] + ([] if args.no_widen else [b for b in WIDER_BANDS if b > args.band])
+    folios: dict[int, int] = {}
+    result: dict = {}
+    for attempt, band in enumerate(bands):
+        if attempt and not args.quiet:
+            print(f"  inconclusive at band {bands[attempt - 1]}; retrying at band {band}",
+                  file=sys.stderr, flush=True)
+        folios = read_folios(args.pdf, dpi=args.dpi, band=band,
+                             pages=args.pages, progress=progress)
+        result = analyse(folios, scanned)
+        result["band"] = band
+        # Only an inconclusive pass is retried, so widening can never turn one verdict
+        # into a different one — only "cannot say" into an answer.
+        if result["conclusive"]:
+            break
     result["pdf"] = os.path.basename(args.pdf)
     result["folios"] = {str(k): v for k, v in sorted(folios.items())}
 


### PR DESCRIPTION
## The problem

"Inconclusive" is the honest answer when folios cannot be read. It is only *useful* if it means **the book cannot be verified** rather than **the band was wrong**.

`marrow-behind-the-executive-mask` separated those:

| attempt | folios read |
|---|---|
| 300 DPI, default band 0.11 | 41 / 146 (28.1%) |
| **400 DPI**, default band | 47 / 146 (32.2%) — still inconclusive |
| 300 DPI, **band 0.17** | **126 / 146 (86.3%)** ✅ |

Resolution was never the problem. Rendering a page and looking at it showed why — the folio sits at the end of the running head:

> *The Second Week: Emphasis on the Group  •  **101***

about **13% down the page**, while the band was the top **11%**. The tool was cutting the folio off and reporting inconclusive on a book whose page numbers are perfectly legible.

## The change

An inconclusive pass retries at wider bands (`WIDER_BANDS = (0.17, 0.24)`; `--no-widen` disables).

- Widening runs **only after** a pass fails to conclude, so it can never turn one verdict into another — only "cannot say" into an answer.
- The band that produced a verdict is **reported with it**. Two runs of the same book can now read different numbers of folios, and a result nobody can reproduce is not evidence.

End to end on the real book:

```
  inconclusive at band 0.11; retrying at band 0.17
pages 146, folios read 126 (86.3%), margin band 0.17
  dominant offset +1 on 124 pages
  NO PAGINATION ANOMALY.
```

## On the tests

The first attempt at this feature was a **silent no-op**. The loop never landed in the file, so `--no-widen` existed and did nothing — while the constant and the render line were both present and both tested. Every test passed. Nothing exercised `main()`.

The tests here drive `main()` with a stubbed reader and assert the retry actually happens. They fail against the version without the loop:

```
assert len(calls) > 1, "main() never retried — the widening loop is a no-op"
E   AssertionError: main() never retried
```

A test that cannot observe the behaviour it names is not a test of it.

28 tests. Full suite 378. README, CLAUDE.md and `8-DECISIONS/2026-08-17-folio-verification.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)