### PR TITLE
Pin marker 2.0 as the floor, and document the dependency it needs

### DIFF
--- a/8-DECISIONS/2026-08-17-marker-2-adoption.md
+++ b/8-DECISIONS/2026-08-17-marker-2-adoption.md
@@ -1,0 +1,92 @@
+---
+type: decision
+date: 2026-08-17
+status: accepted
+tags: [marker, ocr, quality, dependencies]
+---
+
+# marker 2.0 is the floor
+
+## Decision
+
+`requirements-marker.txt` pins `marker-pdf>=2.0.0`, and the install docs name the
+`llama.cpp` system dependency that 2.x needs and pip cannot supply.
+
+## Why: 1.10.2 writes text that was never in the book
+
+Handed a blank page — a part-divider verso, a half-title, an unnumbered leaf — marker
+1.10.2 has nothing to transcribe and does not stop. It emits a repeating n-gram until
+it reaches a token cap, producing about **2,046 characters of prose-shaped text**:
+
+```
+The state of the state of the state of the state of the state of the state ...
+and House and House and House and House and House and House and House ...
+```
+
+Measured over one corpus of 955 converted sources, **16 books carried 44 such
+passages.** They survive every gate that reads structure rather than prose: pagination
+stays coherent, figures still resolve, the quality score is unaffected.
+
+The danger is not that the text is obviously garbage. It is that it *sits in a filed
+source as if it were the book*, and anything reading that file — a person, a quote
+checker, a model — has no way to know the difference without being told to look.
+
+## Why 2.0 fixes it
+
+Verified rather than assumed. Both books were converted twice at the same page ranges,
+under 1.10.2 as a control and under 2.0.0:
+
+| book | 1.10.2 (control) | 2.0.0 |
+|---|---|---|
+| Grove, *High Output Management* | 12 degenerate lines reproduced | clean |
+| Cringely, *Accidental Empires* | 8 degenerate lines reproduced | clean |
+
+The control arm is the load-bearing half. A clean 2.0 result proves nothing unless the
+failure reproduces under the version that produced it — and on a third book (a single
+near-blank page) it did **not** reproduce, which is exactly why one book would have been
+insufficient evidence.
+
+**The root cause turns out to be simpler than "a token cap."** Every affected page is
+blank or near-blank, and 2.0 emits *nothing* on those same pages while returning full
+text on content pages in the same run. 1.10.2 was not corrupting prose; it was
+inventing it where there was none.
+
+Consequence worth recording: **no reconversion was needed for content recovery.** All 14
+wholly-noise pages across those 16 books were blank leaves. What 1.x produced was
+additive junk, not lost text.
+
+## The dependency, which is a trap either way
+
+marker 2 runs Surya OCR 2 through a llama.cpp backend on CPU and MPS, and aborts with
+`SpawnError: llama-server binary not found` without it. That crash arrives at the **end**
+of a long conversion.
+
+This was already live before this decision: `requirements-marker.txt` pinned no version,
+so anyone installing fresh already got 2.x and then hit an unexplained crash with nothing
+in the README about it. Pinning the floor does not create the dependency; it documents
+one that was already reaching people.
+
+## Compatibility
+
+Every flag `convert.py` passes to marker exists in 2.0, checked against its `--help`
+rather than assumed: `--paginate_output`, `--keep_pageheader_in_output`,
+`--keep_pagefooter_in_output`, `--disable_image_extraction`, `--output_dir`. The
+`{N}------` page separator that `_MARKER_PAGE_SEPARATOR_RE` parses is unchanged, and
+page indices are stable — of ten Cringely pages probed, the eight carrying a readable
+folio gave the same value at the same sheet under both versions, at a constant offset of
+13. The other two carry no folio under either version.
+
+That last check mattered more than the others. A rewritten layout model could have moved
+where page breaks land, and a shifted page map would have silently invalidated every
+printed-page citation into that book while looking perfectly healthy.
+
+## Consequences
+
+- Existing `.venv-marker` installs on 1.x must be upgraded, and `brew install llama.cpp`
+  added. Nothing detects a stale venv; the symptom is silent, and it is old conversions
+  looking fine.
+- Conversions produced under 1.x are not retroactively suspect in their *prose*, but may
+  carry the blank-page passages. `mc-wiki/tools/check-degenerate-text.py` finds them.
+- marker 2 defaults to `fast` mode on CPU/MPS and `balanced` on GPU. Only the CPU/MPS
+  default was exercised here; it produced correct text on content pages. `balanced` is
+  untested in this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ The marginal cost of completeness is near zero with AI. Do the whole thing. Do i
 - The `clean_title()` function strips version markers (e.g., "V3") from filenames for cleaner titles
 - Inspect the `.report.json` sidecar to see what happened: `jq '.method,.extracted_assets,.quality_score' output/*.report.json`
 
+## marker 2.0 is the floor
+
+`requirements-marker.txt` pins `marker-pdf>=2.0.0`. marker 1.10.2 **hallucinates on blank pages** — finding nothing to transcribe it emits a repeating n-gram to a token cap, ~2,046 characters of prose-shaped text that was never in the book. Never assume a conversion from 1.x is clean; `mc-wiki/tools/check-degenerate-text.py` finds these.
+
+marker 2 needs `llama-server` (`brew install llama.cpp`) for its CPU/MPS backend, and fails at the END of a conversion without it. All flags `convert.py` passes (`--paginate_output`, `--keep_pageheader_in_output`, `--keep_pagefooter_in_output`, `--disable_image_extraction`, `--output_dir`) exist in 2.0 and were checked against its `--help`. See `8-DECISIONS/2026-08-17-marker-2-adoption.md`.
+
 ## Verifying a scan's page numbers
 
 `convert.py` reads printed folios where it can and **interpolates** the rest from a consensus offset. That leaves the output part measured and part computed, and nothing downstream can tell which is which. The failure it cannot survive is a **pagination shift** — an unnumbered plate section or bound-in map — because one constant offset is then applied over the top and every folio past it is smoothly, self-consistently wrong.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ python3.12 -m venv .venv-marker
 .venv-marker/bin/pip install -r requirements-docling.txt       # docling
 ```
 
+**`marker-pdf` also needs a system dependency pip cannot install:**
+
+```bash
+brew install llama.cpp
+```
+
+marker 2 runs Surya OCR 2 through a llama.cpp backend on CPU and MPS. Without the
+`llama-server` binary it aborts with `SpawnError: llama-server binary not found` —
+and that arrives at the *end* of a long conversion, which is the worst possible
+place to find out.
+
+**marker 2.0 is a floor, not a preference.** marker 1.10.2 hallucinates on blank
+pages: with nothing to transcribe it emits a repeating n-gram until it hits a token
+cap, writing ~2,046 characters of prose-shaped text that was never in the book. 2.0
+emits nothing on the same pages. If you are on 1.x, upgrade before converting
+anything you intend to quote. See
+[`8-DECISIONS/2026-08-17-marker-2-adoption.md`](8-DECISIONS/2026-08-17-marker-2-adoption.md).
+
 ### OCR backend
 
 ```bash

--- a/requirements-marker.txt
+++ b/requirements-marker.txt
@@ -1,5 +1,21 @@
 # Python 3.10+ only. Install into .venv-marker:
 #   python3.12 -m venv .venv-marker
 #   .venv-marker/bin/pip install -r requirements-marker.txt
+#
+# REQUIRES A SYSTEM DEPENDENCY that pip cannot install:
+#
+#   brew install llama.cpp        (macOS / Linux)
+#
+# marker 2 runs Surya OCR 2 through a llama.cpp backend on CPU and MPS, and aborts
+# with `SpawnError: llama-server binary not found` without it. That crash arrives at
+# the END of a long conversion, which is the worst place to discover a missing
+# dependency.
+#
+# The floor is 2.0 deliberately, not for features. marker 1.10.2 HALLUCINATES ON
+# BLANK PAGES: finding nothing to transcribe, it emits a repeating n-gram until it
+# hits a token cap, producing ~2,046 characters of prose-shaped text that was never
+# in the book. Measured across one 955-source corpus, 16 books carried 44 such
+# passages. 2.0 emits nothing on the same pages. See
+# 8-DECISIONS/2026-08-17-marker-2-adoption.md.
 -r requirements.txt
-marker-pdf
+marker-pdf>=2.0.0

--- a/tests/test_marker_version_floor.py
+++ b/tests/test_marker_version_floor.py
@@ -1,0 +1,50 @@
+"""marker 2.0 is a correctness floor, and the docs that get someone there must agree.
+
+marker 1.10.2 hallucinates on blank pages: with nothing to transcribe it emits a repeating
+n-gram to a token cap, ~2,046 characters of prose-shaped text that was never in the book.
+So the pin is not a preference, and it is not enough on its own — 2.x also needs a
+`llama-server` binary that pip cannot install, and it fails at the END of a long
+conversion without it.
+
+Per the enforced-invariant rule: when a requirement becomes enforced, every documented
+path that produces it changes in the same commit. These tests are that rule made
+mechanical, so the pin and the install docs cannot drift apart silently.
+
+See 8-DECISIONS/2026-08-17-marker-2-adoption.md.
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REQS = (ROOT / "requirements-marker.txt").read_text()
+
+
+def test_marker_is_pinned_to_2_or_newer():
+    m = re.search(r"^marker-pdf\s*(.*)$", REQS, re.M)
+    assert m, "requirements-marker.txt no longer pins marker-pdf at all"
+    spec = m.group(1).strip()
+    assert spec, (
+        "marker-pdf is unpinned. An unpinned install silently accepts 1.x, which writes "
+        "text that was never in the book."
+    )
+    floor = re.match(r">=\s*(\d+)", spec)
+    assert floor and int(floor.group(1)) >= 2, f"marker-pdf floor is {spec!r}, must be >=2.0.0"
+
+
+def test_the_system_dependency_is_documented_where_someone_installing_will_see_it():
+    """A pin that produces an unexplained crash is a trap, not a fix. The llama.cpp
+    requirement has to appear in the file the installer reads AND in the README block
+    that tells them what to run."""
+    assert "llama.cpp" in REQS, "requirements-marker.txt does not mention llama.cpp"
+    readme = (ROOT / "README.md").read_text()
+    assert "brew install llama.cpp" in readme, "README does not give the install command"
+    assert "llama-server" in readme, "README does not name the error the operator will see"
+
+
+def test_the_reason_for_the_floor_is_recorded_not_just_the_floor():
+    """A bare version pin invites someone to relax it. The requirements file has to say
+    what breaks, so the next person reads a reason rather than a number."""
+    assert re.search(r"hallucinat|never in the book", REQS, re.I), (
+        "requirements-marker.txt pins a floor without saying why 1.x is unsafe"
+    )
+    assert (ROOT / "8-DECISIONS" / "2026-08-17-marker-2-adoption.md").exists()


### PR DESCRIPTION
## marker 1.10.2 writes text that was never in the book

Handed a blank page — a part-divider verso, a half-title, an unnumbered leaf — it has nothing to transcribe and does not stop. It emits a repeating n-gram until it hits a token cap, producing ~2,046 characters of prose-shaped text:

```
The state of the state of the state of the state of the state of the state ...
and House and House and House and House and House and House and House ...
```

Over one corpus of **955 converted sources, 16 books carried 44 such passages.** They survive every gate that reads structure rather than prose: pagination stays coherent, figures still resolve, the quality score is unaffected.

The danger is not that it looks like garbage. It is that it **sits in a filed source as if it were the book**.

## 2.0 fixes it — verified, with a control

Both books converted twice over the same page ranges, 1.10.2 as control and 2.0.0:

| book | 1.10.2 (control) | 2.0.0 |
|---|---|---|
| Grove, *High Output Management* | 12 degenerate lines reproduced | clean |
| Cringely, *Accidental Empires* | 8 degenerate lines reproduced | clean |

**The control arm is load-bearing.** A third book did *not* reproduce the failure, so one book would have proved nothing.

**The root cause is simpler than "a token cap."** Every affected page is blank or near-blank, and 2.0 emits *nothing* on those pages while returning full text on content pages in the same run. 1.x was not corrupting prose — it was inventing it where there was none. So **no reconversion is needed to recover content**: all 14 wholly-noise pages across those 16 books were blank leaves.

## The llama.cpp dependency was already a trap

`requirements-marker.txt` pinned **no version**, so a fresh install has been getting 2.x for weeks — and then hitting `SpawnError: llama-server binary not found`, at the *end* of a long conversion, with nothing in the README about it.

Pinning the floor does not create that dependency. It documents one that was already reaching people.

## Compatibility, checked not assumed

Against marker 2.0's own `--help`: every flag `convert.py` passes exists (`--paginate_output`, `--keep_pageheader_in_output`, `--keep_pagefooter_in_output`, `--disable_image_extraction`, `--output_dir`), the `{N}------` separator is unchanged, and **page indices are stable** — of ten Cringely pages probed, the eight carrying a readable folio gave the same value at the same sheet under both versions, at a constant offset of 13.

That last check mattered most. A rewritten layout model could have moved where page breaks land, and a shifted page map would silently invalidate every printed-page citation into a book while looking perfectly healthy.

## Tests

Three, all failing against the previous state:

- the pin exists and its floor is ≥ 2
- the system dependency appears in **both** files an installer reads — the requirements file *and* the README block that tells them what to run, including the error text they will see
- the requirements file states **why** 1.x is unsafe, not just a number. A bare pin invites the next person to relax it.

381 tests. Decision: `8-DECISIONS/2026-08-17-marker-2-adoption.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)