### PR TITLE
AI-review gate — required PR-body review record (wiki-reliability Phase 4.2)

### DIFF
--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -67,13 +67,17 @@ jobs:
         # PR_LISTED_FILES counts the entries the endpoint actually returned
         # (it caps at 3,000): the predicate compares it against the PR's
         # changed_files count and fails closed on truncation (codex r2, P2).
+        # Paths are base64-encoded per entry (#52 verify round, P1): git
+        # permits newlines in filenames, and raw lines would let one
+        # hostile filename split into several exempt-looking paths or
+        # inject tag/count lines into this line-oriented hand-off.
         run: |
           set -euo pipefail
           gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --paginate --jq '.[] | "F\t" + .filename, (if .previous_filename then "P\t" + .previous_filename else empty end)' \
+            --paginate --jq '.[] | "F " + (.filename | @base64), (if .previous_filename then "P " + (.previous_filename | @base64) else empty end)' \
             > /tmp/changed-raw.txt
-          cut -f2- /tmp/changed-raw.txt > /tmp/changed-files.txt
-          listed=$(grep -c '^F' /tmp/changed-raw.txt || true)
+          cut -d' ' -f2 /tmp/changed-raw.txt > /tmp/changed-files.txt
+          listed=$(grep -c '^F ' /tmp/changed-raw.txt || true)
           echo "PR_LISTED_FILES=$listed" >> "$GITHUB_ENV"
           echo "$listed entry(ies) listed; $(wc -l < /tmp/changed-files.txt) path(s) fed (renames counted on both sides)."
 
@@ -82,4 +86,5 @@ jobs:
           # Env var, never shell interpolation: the body is untrusted input.
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
+          PR_PATHS_BASE64: "1"
         run: /tmp/check-ai-review.sh < /tmp/changed-files.txt

--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -64,13 +64,22 @@ jobs:
       - name: List the PR's changed files
         # Renames contribute BOTH sides: previous_filename too, so a code
         # file renamed into docs/ cannot read as docs-only (codex r1, P2).
+        # PR_LISTED_FILES counts the entries the endpoint actually returned
+        # (it caps at 3,000): the predicate compares it against the PR's
+        # changed_files count and fails closed on truncation (codex r2, P2).
         run: |
+          set -euo pipefail
           gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --paginate --jq '.[] | .filename, (.previous_filename // empty)' > /tmp/changed-files.txt
-          echo "$(wc -l < /tmp/changed-files.txt) changed path(s) (renames counted on both sides)."
+            --paginate --jq '.[] | "F\t" + .filename, (if .previous_filename then "P\t" + .previous_filename else empty end)' \
+            > /tmp/changed-raw.txt
+          cut -f2- /tmp/changed-raw.txt > /tmp/changed-files.txt
+          listed=$(grep -c '^F' /tmp/changed-raw.txt || true)
+          echo "PR_LISTED_FILES=$listed" >> "$GITHUB_ENV"
+          echo "$listed entry(ies) listed; $(wc -l < /tmp/changed-files.txt) path(s) fed (renames counted on both sides)."
 
       - name: Require the AI-review section
         env:
           # Env var, never shell interpolation: the body is untrusted input.
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
         run: /tmp/check-ai-review.sh < /tmp/changed-files.txt

--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -5,18 +5,28 @@
 # tools/, scripts/, gates, or conversion code get a different-model review
 # (Claude-built -> Codex; Codex-built -> Claude), exactly two rounds,
 # recorded in the PR body as `## AI review — rounds: 2, engine, verdict`.
-# Pure-docs PRs (every changed file *.md or under docs/) are exempt.
+# Pure-docs PRs are exempt; the mandatory/exempt classification lives in
+# the predicate, scripts/ci/check-ai-review.sh.
 #
-# Deliberately cheap: NO repo checkout — the output corpus is heavy, and the
-# gate only needs (a) the changed-file listing and (b) the PR body, both from
-# the API. The one repo file it needs, the predicate script, is fetched via
-# the contents API from the BASE branch, so a PR cannot rewrite its own gate
-# (fallback to the PR head only when the base doesn't hold the script yet —
-# i.e. the bootstrap PR that introduces it).
+# Trigger is pull_request_target ON PURPOSE (codex round 1, P1): with plain
+# pull_request a PR that edits THIS FILE runs its own edited definition, so
+# it can replace the job with unconditional success before the base-fetched
+# predicate ever runs. pull_request_target runs the BASE branch's workflow
+# definition, closing that hole. Consequence: the gate validates a change
+# to itself only AFTER that change merges (the bootstrap PR ran green under
+# the old trigger; see PR #52).
 #
-# The predicate itself lives in scripts/ci/check-ai-review.sh — standalone on
-# purpose, because a workflow cannot be executed locally; it runs red and
-# green in scripts/ci/check-ai-review.test.sh.
+# pull_request_target SECURITY: this job must NEVER execute head content.
+# It has no checkout step at all; changed files and the PR body come from
+# the API (body only ever into an env var, never shell-interpolated); the
+# one script it runs is fetched via the contents API from the BASE branch.
+# Keep it that way — adding `actions/checkout` of the head ref here would
+# hand the PR author code execution with a base-context token.
+#
+# Deliberately cheap otherwise: the output corpus is heavy, and the gate
+# only needs the diff listing and the body. The predicate is standalone
+# (a workflow cannot be executed locally) and runs red and green in
+# scripts/ci/check-ai-review.test.sh.
 #
 # NOTE: a workflow alone only REPORTS. To make it BLOCK merges, the check
 # must be marked required in branch protection — see the PR that introduced
@@ -24,7 +34,7 @@
 name: AI review gate
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
@@ -42,23 +52,22 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Fetch the gate predicate from the base branch
+        # Base branch only — no head fallback: under pull_request_target the
+        # workflow definition itself is already the base's, and fetching the
+        # predicate from the head would let a PR rewrite its own gate.
         run: |
           set -euo pipefail
-          fetch() {
-            gh api "repos/${{ github.repository }}/contents/scripts/ci/check-ai-review.sh?ref=$1" \
-              --jq .content | base64 -d > /tmp/check-ai-review.sh
-          }
-          if ! fetch "${{ github.event.pull_request.base.ref }}"; then
-            echo "Predicate not on base branch yet (bootstrap PR) — using the PR head copy."
-            fetch "${{ github.event.pull_request.head.sha }}"
-          fi
+          gh api "repos/${{ github.repository }}/contents/scripts/ci/check-ai-review.sh?ref=${{ github.event.pull_request.base.ref }}" \
+            --jq .content | base64 -d > /tmp/check-ai-review.sh
           chmod +x /tmp/check-ai-review.sh
 
       - name: List the PR's changed files
+        # Renames contribute BOTH sides: previous_filename too, so a code
+        # file renamed into docs/ cannot read as docs-only (codex r1, P2).
         run: |
           gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --paginate --jq '.[].filename' > /tmp/changed-files.txt
-          echo "$(wc -l < /tmp/changed-files.txt) changed file(s)."
+            --paginate --jq '.[] | .filename, (.previous_filename // empty)' > /tmp/changed-files.txt
+          echo "$(wc -l < /tmp/changed-files.txt) changed path(s) (renames counted on both sides)."
 
       - name: Require the AI-review section
         env:

--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -1,0 +1,67 @@
+# Require the different-model review record on every non-docs PR.
+# wiki-reliability Phase 4.2, ruling § 9.2 (management-craft
+# docs/2B-PROJECTS/wiki-reliability/v1/RESEARCH.md; written rule at
+# ~/.claude/CLAUDE.md § "Different-model review gate"): PRs touching raw/,
+# tools/, scripts/, gates, or conversion code get a different-model review
+# (Claude-built -> Codex; Codex-built -> Claude), exactly two rounds,
+# recorded in the PR body as `## AI review — rounds: 2, engine, verdict`.
+# Pure-docs PRs (every changed file *.md or under docs/) are exempt.
+#
+# Deliberately cheap: NO repo checkout — the output corpus is heavy, and the
+# gate only needs (a) the changed-file listing and (b) the PR body, both from
+# the API. The one repo file it needs, the predicate script, is fetched via
+# the contents API from the BASE branch, so a PR cannot rewrite its own gate
+# (fallback to the PR head only when the base doesn't hold the script yet —
+# i.e. the bootstrap PR that introduces it).
+#
+# The predicate itself lives in scripts/ci/check-ai-review.sh — standalone on
+# purpose, because a workflow cannot be executed locally; it runs red and
+# green in scripts/ci/check-ai-review.test.sh.
+#
+# NOTE: a workflow alone only REPORTS. To make it BLOCK merges, the check
+# must be marked required in branch protection — see the PR that introduced
+# this file.
+name: AI review gate
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ai-review-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Fetch the gate predicate from the base branch
+        run: |
+          set -euo pipefail
+          fetch() {
+            gh api "repos/${{ github.repository }}/contents/scripts/ci/check-ai-review.sh?ref=$1" \
+              --jq .content | base64 -d > /tmp/check-ai-review.sh
+          }
+          if ! fetch "${{ github.event.pull_request.base.ref }}"; then
+            echo "Predicate not on base branch yet (bootstrap PR) — using the PR head copy."
+            fetch "${{ github.event.pull_request.head.sha }}"
+          fi
+          chmod +x /tmp/check-ai-review.sh
+
+      - name: List the PR's changed files
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename' > /tmp/changed-files.txt
+          echo "$(wc -l < /tmp/changed-files.txt) changed file(s)."
+
+      - name: Require the AI-review section
+        env:
+          # Env var, never shell interpolation: the body is untrusted input.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: /tmp/check-ai-review.sh < /tmp/changed-files.txt

--- a/scripts/ci/check-ai-review.sh
+++ b/scripts/ci/check-ai-review.sh
@@ -12,16 +12,24 @@
 # Input:  changed file paths on stdin, one per line — for renames the
 #         workflow feeds BOTH sides (filename + previous_filename), so a
 #         code file renamed into docs/ still reads as code; the PR body
-#         in $PR_BODY.
+#         in $PR_BODY. Optionally $PR_CHANGED_FILES (the PR API's
+#         changed_files count) and $PR_LISTED_FILES (how many entries the
+#         file listing actually returned): the pulls/files endpoint caps
+#         at 3,000 entries, so listed < changed means the listing is
+#         truncated and the diff CANNOT be classified — fail closed by
+#         treating the PR as mandatory-review.
 # Exempt (sourceconvert: everything in this repo IS conversion code, so
 #         the exemption is narrow): *.md under docs/, and root-level *.md
 #         EXCEPT CLAUDE.md (an agent contract over conversion behavior,
 #         not prose). Everything else — convert.py, scripts/, tests/,
 #         .github/, output/, requirements — is mandatory-review.
-# Pass:   otherwise, when the body contains an `## AI review` heading,
-#         "rounds: 2" (exactly 2 — 1, 12, 2+, 2.5 all fail), a named
-#         engine, and a verdict. Lenient on formatting, strict on those
-#         four facts.
+# Pass:   otherwise, when the body carries ONE `## AI review` section
+#         (heading to the next `## ` or EOF) and INSIDE that slice:
+#         "rounds: 2" (exactly 2 — 1, 12, 2+, 2.5 fail; sentence-final
+#         "2." passes), an engine with a real value, and a verdict with a
+#         real value (a bare "engine: ," or "verdict:" fails; template
+#         text elsewhere in the body supplies nothing). Lenient on
+#         formatting, strict on those facts.
 # Exit 0 pass / 1 fail.
 #
 # Standalone on purpose: an Actions workflow cannot be executed locally,
@@ -48,13 +56,25 @@ if [ "${#files[@]}" -eq 0 ]; then
   exit 0
 fi
 
+# Fail closed on a truncated file listing (pulls/files caps at 3,000).
+truncated=false
+if [ -n "${PR_CHANGED_FILES-}" ] && [ -n "${PR_LISTED_FILES-}" ] \
+   && [ "${PR_LISTED_FILES}" -lt "${PR_CHANGED_FILES}" ]; then
+  truncated=true
+  echo "File listing truncated (${PR_LISTED_FILES} of ${PR_CHANGED_FILES} entries) — PR too large to classify; treating as mandatory-review."
+fi
+
 docs_only=true
-for f in "${files[@]}"; do
-  if ! exempt "$f"; then
-    docs_only=false
-    break
-  fi
-done
+if [ "$truncated" = true ]; then
+  docs_only=false
+else
+  for f in "${files[@]}"; do
+    if ! exempt "$f"; then
+      docs_only=false
+      break
+    fi
+  done
+fi
 
 if [ "$docs_only" = true ]; then
   echo "Docs-only PR (every changed file *.md under docs/ or at the root, none an agent contract) — exempt from the AI-review gate."
@@ -63,11 +83,25 @@ fi
 
 body="${PR_BODY-}"
 
+# Extract ONE section: the first `## AI review` heading through the line
+# before the next `## ` heading (or EOF). All field checks run inside this
+# slice, so stale template text elsewhere in the body supplies nothing —
+# and lines inside <!-- --> comment blocks are skipped, so a commented-out
+# template cannot open the section either.
+section=$(printf '%s\n' "$body" | awk '
+  !incomment && /<!--/ && !/-->/ { incomment = 1; next }
+  incomment && /-->/             { incomment = 0; next }
+  incomment                      { next }
+  insec && $0 ~ /^[[:space:]]*## / { exit }
+  insec { print; next }
+  tolower($0) ~ /^[[:space:]]*##[[:space:]]*ai review/ { insec = 1; print }
+')
+
 ok=true
-printf '%s' "$body" | grep -Eiq '^[[:space:]]*##[[:space:]]*AI review'        || ok=false
-printf '%s' "$body" | grep -Eiq 'rounds:[[:space:]]*2([[:space:],;)]|$)'      || ok=false
-printf '%s' "$body" | grep -Eiq 'engine[:[:space:]][[:space:]]*[^[:space:]]+' || ok=false
-printf '%s' "$body" | grep -Eiq 'verdict'                                     || ok=false
+[ -n "$section" ] || ok=false
+printf '%s' "$section" | grep -Eiq 'rounds:[[:space:]]*2([[:space:],;)]|\.([^0-9]|$)|$)'  || ok=false
+printf '%s' "$section" | grep -Eiq 'engine[:[:space:]][[:space:]]*[^[:space:]]*[[:alnum:]]'  || ok=false
+printf '%s' "$section" | grep -Eiq 'verdict[:[:space:]][[:space:]]*[^[:space:]]*[[:alnum:]]' || ok=false
 
 if [ "$ok" = true ]; then
   echo "AI-review section found (rounds: 2 + engine + verdict recorded)."
@@ -80,7 +114,8 @@ body must record the different-model review (Claude-built -> Codex
 reviews; Codex-built -> Claude reviews). Exactly two rounds: round 1
 finds, fix the actionables, round 2 verifies the fixes, then STOP.
 
-Add a section like this to the PR body:
+Add ONE section like this to the PR body — all three fields, with real
+values, inside the section itself:
 
   ## AI review — rounds: 2, engine: codex, verdict: pass
 

--- a/scripts/ci/check-ai-review.sh
+++ b/scripts/ci/check-ai-review.sh
@@ -4,23 +4,39 @@
 # docs/2B-PROJECTS/wiki-reliability/v1/RESEARCH.md; written rule at
 # ~/.claude/CLAUDE.md § "Different-model review gate").
 #
-# PRs that touch anything beyond docs get a different-model review —
-# exactly two rounds — recorded in the PR body as an `## AI review`
-# section. This script is the whole predicate; the workflow
+# PRs that touch anything beyond documentation get a different-model
+# review — exactly two rounds — recorded in the PR body as an
+# `## AI review` section. This script is the whole predicate; the workflow
 # (.github/workflows/ai-review-gate.yml) only feeds it.
 #
-# Input:  changed file paths on stdin, one per line (the workflow feeds it
-#         the pulls/N/files listing); the PR body in $PR_BODY.
-# Exempt: when EVERY changed path is a *.md file or under docs/.
+# Input:  changed file paths on stdin, one per line — for renames the
+#         workflow feeds BOTH sides (filename + previous_filename), so a
+#         code file renamed into docs/ still reads as code; the PR body
+#         in $PR_BODY.
+# Exempt (sourceconvert: everything in this repo IS conversion code, so
+#         the exemption is narrow): *.md under docs/, and root-level *.md
+#         EXCEPT CLAUDE.md (an agent contract over conversion behavior,
+#         not prose). Everything else — convert.py, scripts/, tests/,
+#         .github/, output/, requirements — is mandatory-review.
 # Pass:   otherwise, when the body contains an `## AI review` heading,
-#         "rounds: 2" (exactly 2 — "rounds: 1" fails), and a verdict.
-#         Lenient on formatting, strict on those three facts.
+#         "rounds: 2" (exactly 2 — 1, 12, 2+, 2.5 all fail), a named
+#         engine, and a verdict. Lenient on formatting, strict on those
+#         four facts.
 # Exit 0 pass / 1 fail.
 #
 # Standalone on purpose: an Actions workflow cannot be executed locally,
-# but this can — scripts/ci/check-ai-review.test.sh runs it red (mixed
-# diff, no section; rounds: 1) and green (compliant body; docs-only diff).
+# but this can — scripts/ci/check-ai-review.test.sh runs it red and green.
 set -euo pipefail
+
+exempt() {  # $1 = path; docs-shaped?
+  case "$1" in
+    CLAUDE.md) return 1 ;;  # agent contract, never exempt
+    docs/*.md) return 0 ;;  # markdown under docs/ (any depth)
+    */*)       return 1 ;;  # every other nested path is code/corpus
+    *.md)      return 0 ;;  # root-level markdown (README, ROADMAP, ...)
+  esac
+  return 1
+}
 
 files=()
 while IFS= read -r line; do
@@ -34,41 +50,42 @@ fi
 
 docs_only=true
 for f in "${files[@]}"; do
-  case "$f" in
-    docs/*) ;;
-    *.md)   ;;
-    *) docs_only=false; break ;;
-  esac
+  if ! exempt "$f"; then
+    docs_only=false
+    break
+  fi
 done
 
 if [ "$docs_only" = true ]; then
-  echo "Docs-only PR (every changed file is *.md or under docs/) — exempt from the AI-review gate."
+  echo "Docs-only PR (every changed file *.md under docs/ or at the root, none an agent contract) — exempt from the AI-review gate."
   exit 0
 fi
 
 body="${PR_BODY-}"
 
 ok=true
-printf '%s' "$body" | grep -Eiq '^[[:space:]]*##[[:space:]]*AI review' || ok=false
-printf '%s' "$body" | grep -Eiq 'rounds:[[:space:]]*2([^0-9]|$)'       || ok=false
-printf '%s' "$body" | grep -Eiq 'verdict'                              || ok=false
+printf '%s' "$body" | grep -Eiq '^[[:space:]]*##[[:space:]]*AI review'        || ok=false
+printf '%s' "$body" | grep -Eiq 'rounds:[[:space:]]*2([[:space:],;)]|$)'      || ok=false
+printf '%s' "$body" | grep -Eiq 'engine[:[:space:]][[:space:]]*[^[:space:]]+' || ok=false
+printf '%s' "$body" | grep -Eiq 'verdict'                                     || ok=false
 
 if [ "$ok" = true ]; then
-  echo "AI-review section found (rounds: 2 + verdict recorded)."
+  echo "AI-review section found (rounds: 2 + engine + verdict recorded)."
   exit 0
 fi
 
 cat >&2 <<'EOF'
-FAIL: this PR touches non-docs paths, so its body must record the
-different-model review (Claude-built -> Codex reviews; Codex-built ->
-Claude reviews). Exactly two rounds: round 1 finds, fix the actionables,
-round 2 verifies the fixes, then STOP.
+FAIL: this PR touches conversion code or other non-docs paths, so its
+body must record the different-model review (Claude-built -> Codex
+reviews; Codex-built -> Claude reviews). Exactly two rounds: round 1
+finds, fix the actionables, round 2 verifies the fixes, then STOP.
 
 Add a section like this to the PR body:
 
   ## AI review — rounds: 2, engine: codex, verdict: pass
 
-Docs-only PRs (every changed file *.md or under docs/) are exempt.
+Docs-only PRs (every changed file *.md under docs/ or at the repo root,
+CLAUDE.md excluded) are exempt.
 Ruling: management-craft docs/2B-PROJECTS/wiki-reliability/v1/RESEARCH.md
 § 9.2 (written rule: ~/.claude/CLAUDE.md § "Different-model review gate").
 EOF

--- a/scripts/ci/check-ai-review.sh
+++ b/scripts/ci/check-ai-review.sh
@@ -86,22 +86,41 @@ body="${PR_BODY-}"
 # Extract ONE section: the first `## AI review` heading through the line
 # before the next `## ` heading (or EOF). All field checks run inside this
 # slice, so stale template text elsewhere in the body supplies nothing —
-# and lines inside <!-- --> comment blocks are skipped, so a commented-out
-# template cannot open the section either.
+# and <!-- --> comment content (same-line spans AND multi-line blocks) is
+# stripped first, so a commented-out template supplies nothing either.
 section=$(printf '%s\n' "$body" | awk '
-  !incomment && /<!--/ && !/-->/ { incomment = 1; next }
-  incomment && /-->/             { incomment = 0; next }
-  incomment                      { next }
-  insec && $0 ~ /^[[:space:]]*## / { exit }
-  insec { print; next }
-  tolower($0) ~ /^[[:space:]]*##[[:space:]]*ai review/ { insec = 1; print }
+  {
+    # Close a comment block opened on an earlier line.
+    if (incomment) {
+      e = index($0, "-->")
+      if (e == 0) next
+      $0 = substr($0, e + 3)
+      incomment = 0
+    }
+    # Strip complete same-line <!-- ... --> spans; an unclosed opener
+    # drops the rest of the line and opens a block.
+    while ((s = index($0, "<!--")) > 0) {
+      rest = substr($0, s + 4)
+      e = index(rest, "-->")
+      if (e == 0) { $0 = substr($0, 1, s - 1); incomment = 1; break }
+      $0 = substr($0, 1, s - 1) substr(rest, e + 3)
+    }
+    if (insec && $0 ~ /^[[:space:]]*## /) exit
+    if (insec) { print; next }
+    if (tolower($0) ~ /^[[:space:]]*##[[:space:]]*ai review/) { insec = 1; print }
+  }
 ')
 
+# Field values are bounded at commas/semicolons/whitespace BEFORE requiring
+# an alphanumeric, so an empty field cannot consume the next label
+# ("engine:,verdict:pass" is an empty engine, not engine=",verdict:pass").
+# rounds accepts a sentence-final "2." only at a real token boundary
+# (whitespace or end of line) — "2.5" and "2.foo" both fail.
 ok=true
 [ -n "$section" ] || ok=false
-printf '%s' "$section" | grep -Eiq 'rounds:[[:space:]]*2([[:space:],;)]|\.([^0-9]|$)|$)'  || ok=false
-printf '%s' "$section" | grep -Eiq 'engine[:[:space:]][[:space:]]*[^[:space:]]*[[:alnum:]]'  || ok=false
-printf '%s' "$section" | grep -Eiq 'verdict[:[:space:]][[:space:]]*[^[:space:]]*[[:alnum:]]' || ok=false
+printf '%s' "$section" | grep -Eiq 'rounds:[[:space:]]*2([[:space:],;)]|\.([[:space:]]|$)|$)'   || ok=false
+printf '%s' "$section" | grep -Eiq 'engine[:[:space:]][[:space:]]*[^,;[:space:]]*[[:alnum:]]'  || ok=false
+printf '%s' "$section" | grep -Eiq 'verdict[:[:space:]][[:space:]]*[^,;[:space:]]*[[:alnum:]]' || ok=false
 
 if [ "$ok" = true ]; then
   echo "AI-review section found (rounds: 2 + engine + verdict recorded)."

--- a/scripts/ci/check-ai-review.sh
+++ b/scripts/ci/check-ai-review.sh
@@ -12,7 +12,11 @@
 # Input:  changed file paths on stdin, one per line — for renames the
 #         workflow feeds BOTH sides (filename + previous_filename), so a
 #         code file renamed into docs/ still reads as code; the PR body
-#         in $PR_BODY. Optionally $PR_CHANGED_FILES (the PR API's
+#         in $PR_BODY. With $PR_PATHS_BASE64=1 each stdin line is a
+#         base64-encoded path, decoded here — git permits newlines in
+#         filenames, and raw lines would let one hostile filename
+#         masquerade as several (or inject count/tag lines), so the
+#         workflow always uses this mode. Optionally $PR_CHANGED_FILES (the PR API's
 #         changed_files count) and $PR_LISTED_FILES (how many entries the
 #         file listing actually returned): the pulls/files endpoint caps
 #         at 3,000 entries, so listed < changed means the listing is
@@ -48,7 +52,12 @@ exempt() {  # $1 = path; docs-shaped?
 
 files=()
 while IFS= read -r line; do
-  [ -n "$line" ] && files+=("$line")
+  [ -n "$line" ] || continue
+  if [ "${PR_PATHS_BASE64-}" = "1" ]; then
+    line=$(base64 -d <<<"$line")
+    [ -n "$line" ] || continue
+  fi
+  files+=("$line")
 done
 
 if [ "${#files[@]}" -eq 0 ]; then
@@ -88,8 +97,15 @@ body="${PR_BODY-}"
 # slice, so stale template text elsewhere in the body supplies nothing —
 # and <!-- --> comment content (same-line spans AND multi-line blocks) is
 # stripped first, so a commented-out template supplies nothing either.
-section=$(printf '%s\n' "$body" | awk '
+# The opening heading is end-bounded ("## AI reviewer notes" must not open
+# it); the closing check accepts any whitespace after ## (tabs too). The
+# awk never calls exit — an early exit would SIGPIPE its feeder under
+# pipefail on a large body (shell-cosmetic-measurement class), so it flags
+# `closed` and drains the rest of the input instead; here-strings replace
+# pipelines throughout for the same reason.
+section=$(awk '
   {
+    if (closed) next
     # Close a comment block opened on an earlier line.
     if (incomment) {
       e = index($0, "-->")
@@ -105,22 +121,24 @@ section=$(printf '%s\n' "$body" | awk '
       if (e == 0) { $0 = substr($0, 1, s - 1); incomment = 1; break }
       $0 = substr($0, 1, s - 1) substr(rest, e + 3)
     }
-    if (insec && $0 ~ /^[[:space:]]*## /) exit
+    if (insec && $0 ~ /^[[:space:]]*##[[:space:]]/) { closed = 1; next }
     if (insec) { print; next }
-    if (tolower($0) ~ /^[[:space:]]*##[[:space:]]*ai review/) { insec = 1; print }
+    if (tolower($0) ~ /^[[:space:]]*##[[:space:]]+ai review([^[:alnum:]]|$)/) { insec = 1; print }
   }
-')
+' <<<"$body")
 
 # Field values are bounded at commas/semicolons/whitespace BEFORE requiring
 # an alphanumeric, so an empty field cannot consume the next label
 # ("engine:,verdict:pass" is an empty engine, not engine=",verdict:pass").
-# rounds accepts a sentence-final "2." only at a real token boundary
-# (whitespace or end of line) — "2.5" and "2.foo" both fail.
+# Each label requires a non-word character (or line start) before it, so
+# "backgrounds:" / "notengine:" / "nonverdict:" supply nothing. rounds
+# accepts a sentence-final "2." only at a real token boundary (whitespace
+# or end of line) — "2.5" and "2.foo" both fail.
 ok=true
 [ -n "$section" ] || ok=false
-printf '%s' "$section" | grep -Eiq 'rounds:[[:space:]]*2([[:space:],;)]|\.([[:space:]]|$)|$)'   || ok=false
-printf '%s' "$section" | grep -Eiq 'engine[:[:space:]][[:space:]]*[^,;[:space:]]*[[:alnum:]]'  || ok=false
-printf '%s' "$section" | grep -Eiq 'verdict[:[:space:]][[:space:]]*[^,;[:space:]]*[[:alnum:]]' || ok=false
+grep -Eiq '(^|[^[:alnum:]_])rounds:[[:space:]]*2([[:space:],;)]|\.([[:space:]]|$)|$)'   <<<"$section" || ok=false
+grep -Eiq '(^|[^[:alnum:]_])engine[:[:space:]][[:space:]]*[^,;[:space:]]*[[:alnum:]]'  <<<"$section" || ok=false
+grep -Eiq '(^|[^[:alnum:]_])verdict[:[:space:]][[:space:]]*[^,;[:space:]]*[[:alnum:]]' <<<"$section" || ok=false
 
 if [ "$ok" = true ]; then
   echo "AI-review section found (rounds: 2 + engine + verdict recorded)."

--- a/scripts/ci/check-ai-review.sh
+++ b/scripts/ci/check-ai-review.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# check-ai-review.sh — the different-model review-gate predicate
+# (wiki-reliability Phase 4.2, ruling § 9.2: management-craft
+# docs/2B-PROJECTS/wiki-reliability/v1/RESEARCH.md; written rule at
+# ~/.claude/CLAUDE.md § "Different-model review gate").
+#
+# PRs that touch anything beyond docs get a different-model review —
+# exactly two rounds — recorded in the PR body as an `## AI review`
+# section. This script is the whole predicate; the workflow
+# (.github/workflows/ai-review-gate.yml) only feeds it.
+#
+# Input:  changed file paths on stdin, one per line (the workflow feeds it
+#         the pulls/N/files listing); the PR body in $PR_BODY.
+# Exempt: when EVERY changed path is a *.md file or under docs/.
+# Pass:   otherwise, when the body contains an `## AI review` heading,
+#         "rounds: 2" (exactly 2 — "rounds: 1" fails), and a verdict.
+#         Lenient on formatting, strict on those three facts.
+# Exit 0 pass / 1 fail.
+#
+# Standalone on purpose: an Actions workflow cannot be executed locally,
+# but this can — scripts/ci/check-ai-review.test.sh runs it red (mixed
+# diff, no section; rounds: 1) and green (compliant body; docs-only diff).
+set -euo pipefail
+
+files=()
+while IFS= read -r line; do
+  [ -n "$line" ] && files+=("$line")
+done
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "No changed files — nothing to gate."
+  exit 0
+fi
+
+docs_only=true
+for f in "${files[@]}"; do
+  case "$f" in
+    docs/*) ;;
+    *.md)   ;;
+    *) docs_only=false; break ;;
+  esac
+done
+
+if [ "$docs_only" = true ]; then
+  echo "Docs-only PR (every changed file is *.md or under docs/) — exempt from the AI-review gate."
+  exit 0
+fi
+
+body="${PR_BODY-}"
+
+ok=true
+printf '%s' "$body" | grep -Eiq '^[[:space:]]*##[[:space:]]*AI review' || ok=false
+printf '%s' "$body" | grep -Eiq 'rounds:[[:space:]]*2([^0-9]|$)'       || ok=false
+printf '%s' "$body" | grep -Eiq 'verdict'                              || ok=false
+
+if [ "$ok" = true ]; then
+  echo "AI-review section found (rounds: 2 + verdict recorded)."
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+FAIL: this PR touches non-docs paths, so its body must record the
+different-model review (Claude-built -> Codex reviews; Codex-built ->
+Claude reviews). Exactly two rounds: round 1 finds, fix the actionables,
+round 2 verifies the fixes, then STOP.
+
+Add a section like this to the PR body:
+
+  ## AI review — rounds: 2, engine: codex, verdict: pass
+
+Docs-only PRs (every changed file *.md or under docs/) are exempt.
+Ruling: management-craft docs/2B-PROJECTS/wiki-reliability/v1/RESEARCH.md
+§ 9.2 (written rule: ~/.claude/CLAUDE.md § "Different-model review gate").
+EOF
+exit 1

--- a/scripts/ci/check-ai-review.test.sh
+++ b/scripts/ci/check-ai-review.test.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # check-ai-review.test.sh — verification-gate-symmetry for the AI-review
 # gate predicate: RED on a conversion-code diff+body missing the section,
-# on wrong round counts (1, 12, 2+, 2.5), on a missing engine, and on a
-# rename laundered into docs/; GREEN on a compliant body AND on an exempt
-# docs-only PR.
+# on wrong round counts (1, 12, 2+, 2.5), on empty engine/verdict values,
+# on fields scattered outside the one `## AI review` section, on a rename
+# laundered into docs/, and on a truncated file listing; GREEN on a
+# compliant body AND on an exempt docs-only PR.
 set -euo pipefail
 GUARD="$(cd "$(dirname "$0")" && pwd)/check-ai-review.sh"
 
@@ -13,7 +14,11 @@ COMPLIANT_BODY='Fixes the folio probe.
 
 ## AI review — rounds: 2, engine: codex, verdict: pass
 
-Round 1 found 3 actionables; round 2 verified the fixes.'
+Round 1 found 3 actionables; round 2 verified the fixes.
+
+## Notes
+
+Unrelated section.'
 
 # 1. RED: convert.py diff, body with no AI-review section -> exit 1,
 #    message names the required format and the ruling (codex round 1, P1:
@@ -40,7 +45,8 @@ for p in "scripts/fix_frontmatter.py" "tests/test_cleanup.py" \
 done
 echo "ok 2 - nested .md, docs/ non-md, CLAUDE.md, code + corpus paths never exempt"
 
-# 3. GREEN: conversion-code diff, compliant body -> pass
+# 3. GREEN: conversion-code diff, compliant body (with a trailing unrelated
+#    section — the slice must end at the next `## `) -> pass
 printf 'convert.py\n' \
   | PR_BODY="$COMPLIANT_BODY" "$GUARD" >/dev/null || fail "compliant body refused"
 echo "ok 3 - code diff with compliant section passes"
@@ -57,7 +63,7 @@ printf '%s\n' "README.md" "report.py" \
 set -e
 echo "ok 5 - mixed diff without section fails"
 
-# 6. RED: wrong round counts — 1, 12, 2+, 2.5 (codex round 1, P2)
+# 6. RED: wrong round counts — 1, 12, 2+, 2.5 (codex r1 P2 + r2 P2)
 for bad in \
   '## AI review — rounds: 1, engine: codex, verdict: pass' \
   '## AI review — rounds: 12, engine: codex, verdict: pass' \
@@ -70,42 +76,84 @@ for bad in \
 done
 echo "ok 6 - rounds: 1 / 12 / 2+ / 2.5 all fail"
 
-# 7. RED: no engine named — the record can't support the spot audit
-#    (codex round 1, P1)
-set +e
+# 7. GREEN: sentence-final "rounds: 2." is exactly two (codex round 2, P2)
 printf 'convert.py\n' \
-  | PR_BODY='## AI review — rounds: 2, verdict: pass' "$GUARD" >/dev/null 2>&1 \
-  && fail "engine-less body passed"
-set -e
-echo "ok 7 - section without an engine fails"
+  | PR_BODY='## AI review
+The review ran for rounds: 2.
+engine: codex
+verdict: pass' "$GUARD" >/dev/null || fail "sentence-final 'rounds: 2.' refused"
+echo "ok 7 - sentence-final 'rounds: 2.' passes"
 
-# 8. RED: section + rounds + engine present but no verdict word
+# 8. RED: empty field VALUES — 'engine: ,' and bare 'verdict:' must not
+#    count as records (codex round 2, P1)
+for bad in \
+  '## AI review — rounds: 2, engine: , verdict: pass' \
+  '## AI review — rounds: 2, engine: -, verdict: pass' \
+  '## AI review — rounds: 2, engine: codex, verdict:' \
+  '## AI review — rounds: 2, verdict: pass' \
+  '## AI review — rounds: 2, engine: codex'; do
+  set +e
+  printf 'convert.py\n' | PR_BODY="$bad" "$GUARD" >/dev/null 2>&1 \
+    && fail "incomplete record passed: $bad"
+  set -e
+done
+echo "ok 8 - empty/missing engine or verdict values fail"
+
+# 9. RED: fields OUTSIDE the one AI-review section supply nothing —
+#    split across two sections, or in commented template text
+#    (codex round 2, P1)
 set +e
-printf 'convert.py\n' \
-  | PR_BODY='## AI review — rounds: 2, engine: codex' "$GUARD" >/dev/null 2>&1 \
-  && fail "verdict-less body passed"
-set -e
-echo "ok 8 - section without a verdict fails"
+printf 'convert.py\n' | PR_BODY='## AI review — rounds: 2
 
-# 9. RED: rename laundering — report.py renamed to docs/report.md; the
-#    workflow feeds BOTH sides, and the old side must revoke the exemption
-#    (codex round 1, P2)
+## Notes
+engine: codex, verdict: pass' "$GUARD" >/dev/null 2>&1 && fail "split-section fields passed"
+set -e
+set +e
+printf 'convert.py\n' | PR_BODY='<!-- template:
+## AI review — rounds: 2, engine: codex, verdict: pass
+-->' "$GUARD" >/dev/null 2>&1 && fail "commented template passed"
+set -e
+echo "ok 9 - fields split across sections / commented template fail"
+
+# 10. RED: rename laundering — report.py renamed to docs/report.md; the
+#     workflow feeds BOTH sides, and the old side must revoke the exemption
+#     (codex round 1, P2)
 set +e
 printf '%s\n' "docs/report.md" "report.py" \
   | PR_BODY='No review.' "$GUARD" >/dev/null 2>&1 && fail "rename into docs/ passed"
 set -e
-echo "ok 9 - rename old-side path (report.py -> docs/report.md) revokes exemption"
+echo "ok 10 - rename old-side path (report.py -> docs/report.md) revokes exemption"
 
-# 10. GREEN: lenient formatting — lowercase heading, fields on separate lines
+# 11. RED: truncated file listing (pulls/files caps at 3,000) — a docs-only
+#     PAGE of a larger PR must fail closed as mandatory (codex round 2, P2)
+set +e
+printf 'docs/notes.md\n' \
+  | PR_BODY='No review.' PR_CHANGED_FILES=3500 PR_LISTED_FILES=3000 \
+    "$GUARD" >/dev/null 2>&1 && fail "truncated listing passed as docs-only"
+set -e
+echo "ok 11 - truncated listing (listed < changed) fails closed as mandatory"
+
+# 12. GREEN: truncated listing + compliant body still passes (fail-closed
+#     means mandatory-review, not unconditional failure); and a matching
+#     count keeps the docs-only exemption
+printf 'docs/notes.md\n' \
+  | PR_BODY="$COMPLIANT_BODY" PR_CHANGED_FILES=3500 PR_LISTED_FILES=3000 \
+    "$GUARD" >/dev/null || fail "truncated + compliant body refused"
+printf 'docs/notes.md\n' \
+  | PR_BODY='No review.' PR_CHANGED_FILES=1 PR_LISTED_FILES=1 \
+    "$GUARD" >/dev/null || fail "matching counts lost the exemption"
+echo "ok 12 - truncation is mandatory-not-fatal; matching counts stay exempt"
+
+# 13. GREEN: lenient formatting — lowercase heading, fields on separate lines
 printf 'convert.py\n' \
   | PR_BODY='## ai review
 rounds: 2 (codex round 1 found, round 2 verified)
 engine: codex
 verdict: pass' "$GUARD" >/dev/null || fail "leniently-formatted body refused"
-echo "ok 10 - lenient formatting still passes"
+echo "ok 13 - lenient formatting still passes"
 
-# 11. GREEN: empty diff passes
+# 14. GREEN: empty diff passes
 printf '' | PR_BODY='' "$GUARD" >/dev/null || fail "empty diff refused"
-echo "ok 11 - empty diff passes"
+echo "ok 14 - empty diff passes"
 
 echo "PASS check-ai-review"

--- a/scripts/ci/check-ai-review.test.sh
+++ b/scripts/ci/check-ai-review.test.sh
@@ -169,4 +169,52 @@ echo "ok 13 - lenient formatting still passes"
 printf '' | PR_BODY='' "$GUARD" >/dev/null || fail "empty diff refused"
 echo "ok 14 - empty diff passes"
 
+# 15. RED: newline-in-filename (#52 verify round, P1) — in base64 mode ONE
+#     entry stays ONE path; a filename containing \n that covers a
+#     mandatory path is classified intact, never split into exempt lines.
+enc=$(printf 'scripts/evil.py\nREADME.md' | base64 | tr -d '\n')
+set +e
+printf '%s\n' "$enc" \
+  | PR_BODY='No review.' PR_PATHS_BASE64=1 "$GUARD" >/dev/null 2>&1 \
+  && fail "newline-bearing mandatory filename passed"
+set -e
+# GREEN counterpart: base64 mode still exempts a plain docs path.
+enc=$(printf 'docs/notes.md' | base64 | tr -d '\n')
+printf '%s\n' "$enc" \
+  | PR_BODY='No review.' PR_PATHS_BASE64=1 "$GUARD" >/dev/null \
+  || fail "base64 docs path lost the exemption"
+echo "ok 15 - base64 mode: newline-bearing mandatory filename fails; docs path stays exempt"
+
+# 16. RED: labels inside larger words supply nothing (#52 verify, P2)
+set +e
+printf 'convert.py\n' | PR_BODY='## AI review
+backgrounds: 2, notengine: codex, nonverdict: pass' \
+  "$GUARD" >/dev/null 2>&1 && fail "embedded labels (backgrounds/notengine/nonverdict) passed"
+set -e
+echo "ok 16 - backgrounds:/notengine:/nonverdict: are not rounds/engine/verdict"
+
+# 17. RED: heading boundaries (#52 verify, P2) — '## AI reviewer notes'
+#     must NOT open the section; a tab-headed '##<TAB>Notes' MUST close it.
+set +e
+printf 'convert.py\n' \
+  | PR_BODY='## AI reviewer notes — rounds: 2, engine: codex, verdict: pass' \
+    "$GUARD" >/dev/null 2>&1 && fail "'## AI reviewer notes' opened the section"
+set -e
+set +e
+printf 'convert.py\n' | PR_BODY="$(printf '## AI review — rounds: 2\n##\tNotes\nengine: codex, verdict: pass')" \
+  "$GUARD" >/dev/null 2>&1 && fail "tab-headed heading failed to close the section"
+set -e
+echo "ok 17 - suffixed heading does not open; tab-headed heading closes"
+
+# 18. GREEN: oversized body (#52 verify, P2) — the check must not be
+#     killable by its own plumbing (no early-exiting pipeline / SIGPIPE).
+#     10k lines (~350 KB) is far past the 64 KB pipe buffer that made an
+#     early-exiting awk SIGPIPE its feeder — and >5x GitHub's own 64 KB
+#     PR-body cap, so this over-covers anything the workflow can see.
+big_tail=$( { yes 'filler line for the oversized-body case'; } | head -n 10000 || true)
+printf 'convert.py\n' \
+  | PR_BODY="$(printf '## AI review — rounds: 2, engine: codex, verdict: pass\nround detail\n## Tail\n%s' "$big_tail")" \
+    "$GUARD" >/dev/null || fail "oversized body refused (plumbing killed the check?)"
+echo "ok 18 - oversized body (10k-line tail after the section) passes"
+
 echo "PASS check-ai-review"

--- a/scripts/ci/check-ai-review.test.sh
+++ b/scripts/ci/check-ai-review.test.sh
@@ -68,13 +68,14 @@ for bad in \
   '## AI review — rounds: 1, engine: codex, verdict: pass' \
   '## AI review — rounds: 12, engine: codex, verdict: pass' \
   '## AI review — rounds: 2+, engine: codex, verdict: pass' \
-  '## AI review — rounds: 2.5, engine: codex, verdict: pass'; do
+  '## AI review — rounds: 2.5, engine: codex, verdict: pass' \
+  '## AI review — rounds: 2.foo, engine: codex, verdict: pass'; do
   set +e
   printf 'convert.py\n' | PR_BODY="$bad" "$GUARD" >/dev/null 2>&1 \
     && fail "wrong round count passed: $bad"
   set -e
 done
-echo "ok 6 - rounds: 1 / 12 / 2+ / 2.5 all fail"
+echo "ok 6 - rounds: 1 / 12 / 2+ / 2.5 / 2.foo all fail"
 
 # 7. GREEN: sentence-final "rounds: 2." is exactly two (codex round 2, P2)
 printf 'convert.py\n' \
@@ -89,6 +90,7 @@ echo "ok 7 - sentence-final 'rounds: 2.' passes"
 for bad in \
   '## AI review — rounds: 2, engine: , verdict: pass' \
   '## AI review — rounds: 2, engine: -, verdict: pass' \
+  '## AI review — rounds: 2, engine:,verdict:pass' \
   '## AI review — rounds: 2, engine: codex, verdict:' \
   '## AI review — rounds: 2, verdict: pass' \
   '## AI review — rounds: 2, engine: codex'; do
@@ -97,7 +99,11 @@ for bad in \
     && fail "incomplete record passed: $bad"
   set -e
 done
-echo "ok 8 - empty/missing engine or verdict values fail"
+# GREEN counterpart: the compact no-space form with real values passes.
+printf 'convert.py\n' \
+  | PR_BODY='## AI review — rounds: 2, engine:codex,verdict:pass' \
+    "$GUARD" >/dev/null || fail "compact engine:codex,verdict:pass refused"
+echo "ok 8 - empty engine values (incl. engine:,verdict:pass) fail; compact real values pass"
 
 # 9. RED: fields OUTSIDE the one AI-review section supply nothing —
 #    split across two sections, or in commented template text
@@ -113,7 +119,14 @@ printf 'convert.py\n' | PR_BODY='<!-- template:
 ## AI review — rounds: 2, engine: codex, verdict: pass
 -->' "$GUARD" >/dev/null 2>&1 && fail "commented template passed"
 set -e
-echo "ok 9 - fields split across sections / commented template fail"
+# Same-line HTML comment INSIDE the section supplies nothing either
+# (#52 direct round, P2).
+set +e
+printf 'convert.py\n' | PR_BODY='## AI review
+<!-- rounds: 2, engine: codex, verdict: pass -->' \
+  "$GUARD" >/dev/null 2>&1 && fail "single-line commented template inside section passed"
+set -e
+echo "ok 9 - fields split across sections / commented templates (block + same-line) fail"
 
 # 10. RED: rename laundering — report.py renamed to docs/report.md; the
 #     workflow feeds BOTH sides, and the old side must revoke the exemption

--- a/scripts/ci/check-ai-review.test.sh
+++ b/scripts/ci/check-ai-review.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# check-ai-review.test.sh — verification-gate-symmetry for the AI-review
+# gate predicate: RED on a PR-shaped diff+body missing the section (and on
+# "rounds: 1"), GREEN on a compliant body AND on an exempt docs-only PR.
+set -euo pipefail
+GUARD="$(cd "$(dirname "$0")" && pwd)/check-ai-review.sh"
+
+fail() { echo "FAIL: $*"; exit 1; }
+
+COMPLIANT_BODY='Fixes the folio probe.
+
+## AI review — rounds: 2, engine: codex, verdict: pass
+
+Round 1 found 3 actionables; round 2 verified the fixes.'
+
+# 1. RED: mixed diff (code + docs), body with no AI-review section -> exit 1,
+#    message names the required format and the ruling.
+set +e
+out=$(printf '%s\n' "convert.py" "docs/notes.md" \
+  | PR_BODY='Just a quick fix.' "$GUARD" 2>&1)
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || fail "missing section exited $rc, want 1"
+printf '%s\n' "$out" | grep -q '## AI review' || fail "required format not quoted; got: $out"
+printf '%s\n' "$out" | grep -q '9.2' || fail "ruling not named; got: $out"
+echo "ok 1 - non-docs diff without section fails, quoting format + ruling"
+
+# 2. GREEN: same diff, compliant body -> pass
+printf '%s\n' "convert.py" \
+  | PR_BODY="$COMPLIANT_BODY" "$GUARD" >/dev/null || fail "compliant body refused"
+echo "ok 2 - non-docs diff with compliant section passes"
+
+# 3. GREEN: docs-only diff (*.md anywhere + anything under docs/), no section
+printf '%s\n' "docs/notes.md" "docs/notes.txt" "README.md" \
+  | PR_BODY='No review here.' "$GUARD" >/dev/null || fail "docs-only diff refused"
+echo "ok 3 - docs-only diff without section is exempt"
+
+# 4. RED: one code file among docs revokes the exemption
+set +e
+printf '%s\n' "README.md" "report.py" \
+  | PR_BODY='No review here.' "$GUARD" >/dev/null 2>&1 && fail "mixed diff passed"
+set -e
+echo "ok 4 - mixed diff without section fails"
+
+# 5. RED: "rounds: 1" is not "rounds: 2"; nor is "rounds: 12"
+for bad in \
+  '## AI review — rounds: 1, engine: codex, verdict: pass' \
+  '## AI review — rounds: 12, engine: codex, verdict: pass'; do
+  set +e
+  printf 'report.py\n' | PR_BODY="$bad" "$GUARD" >/dev/null 2>&1 \
+    && fail "wrong round count passed: $bad"
+  set -e
+done
+echo "ok 5 - rounds: 1 / rounds: 12 fail"
+
+# 6. RED: section + rounds present but no verdict word
+set +e
+printf 'report.py\n' \
+  | PR_BODY='## AI review — rounds: 2, engine: codex' "$GUARD" >/dev/null 2>&1 \
+  && fail "verdict-less body passed"
+set -e
+echo "ok 6 - section without a verdict fails"
+
+# 7. GREEN: lenient formatting — lowercase heading, colon-less punctuation
+printf 'report.py\n' \
+  | PR_BODY='## ai review
+rounds: 2 (codex round 1 found, round 2 verified)
+verdict: pass' "$GUARD" >/dev/null || fail "leniently-formatted body refused"
+echo "ok 7 - lenient formatting still passes"
+
+# 8. GREEN: empty diff passes
+printf '' | PR_BODY='' "$GUARD" >/dev/null || fail "empty diff refused"
+echo "ok 8 - empty diff passes"
+
+echo "PASS check-ai-review"

--- a/scripts/ci/check-ai-review.test.sh
+++ b/scripts/ci/check-ai-review.test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # check-ai-review.test.sh — verification-gate-symmetry for the AI-review
-# gate predicate: RED on a PR-shaped diff+body missing the section (and on
-# "rounds: 1"), GREEN on a compliant body AND on an exempt docs-only PR.
+# gate predicate: RED on a conversion-code diff+body missing the section,
+# on wrong round counts (1, 12, 2+, 2.5), on a missing engine, and on a
+# rename laundered into docs/; GREEN on a compliant body AND on an exempt
+# docs-only PR.
 set -euo pipefail
 GUARD="$(cd "$(dirname "$0")" && pwd)/check-ai-review.sh"
 
@@ -13,63 +15,97 @@ COMPLIANT_BODY='Fixes the folio probe.
 
 Round 1 found 3 actionables; round 2 verified the fixes.'
 
-# 1. RED: mixed diff (code + docs), body with no AI-review section -> exit 1,
-#    message names the required format and the ruling.
+# 1. RED: convert.py diff, body with no AI-review section -> exit 1,
+#    message names the required format and the ruling (codex round 1, P1:
+#    conversion code is the gate's primary target here).
 set +e
-out=$(printf '%s\n' "convert.py" "docs/notes.md" \
-  | PR_BODY='Just a quick fix.' "$GUARD" 2>&1)
+out=$(printf 'convert.py\n' | PR_BODY='Just a quick fix.' "$GUARD" 2>&1)
 rc=$?
 set -e
-[ "$rc" -eq 1 ] || fail "missing section exited $rc, want 1"
+[ "$rc" -eq 1 ] || fail "convert.py diff exited $rc, want 1"
 printf '%s\n' "$out" | grep -q '## AI review' || fail "required format not quoted; got: $out"
 printf '%s\n' "$out" | grep -q '9.2' || fail "ruling not named; got: $out"
-echo "ok 1 - non-docs diff without section fails, quoting format + ruling"
+echo "ok 1 - convert.py diff without section fails, quoting format + ruling"
 
-# 2. GREEN: same diff, compliant body -> pass
-printf '%s\n' "convert.py" \
+# 2. RED: non-exempt paths, alone — nested .md outside docs/, non-md under
+#    docs/, CLAUDE.md, code, corpus
+for p in "scripts/fix_frontmatter.py" "tests/test_cleanup.py" \
+         ".github/workflows/x.yml" "output/Management/book.md" \
+         "8-DECISIONS/2026-01-01-x.md" "docs/notes.txt" "CLAUDE.md" \
+         "requirements.txt"; do
+  set +e
+  printf '%s\n' "$p" | PR_BODY='No review.' "$GUARD" >/dev/null 2>&1 \
+    && fail "non-exempt path '$p' passed as docs-only"
+  set -e
+done
+echo "ok 2 - nested .md, docs/ non-md, CLAUDE.md, code + corpus paths never exempt"
+
+# 3. GREEN: conversion-code diff, compliant body -> pass
+printf 'convert.py\n' \
   | PR_BODY="$COMPLIANT_BODY" "$GUARD" >/dev/null || fail "compliant body refused"
-echo "ok 2 - non-docs diff with compliant section passes"
+echo "ok 3 - code diff with compliant section passes"
 
-# 3. GREEN: docs-only diff (*.md anywhere + anything under docs/), no section
-printf '%s\n' "docs/notes.md" "docs/notes.txt" "README.md" \
+# 4. GREEN: docs-only diff (docs/**/*.md + root *.md), no section
+printf '%s\n' "docs/notes.md" "docs/sub/guide.md" "README.md" "1-ROADMAP.md" \
   | PR_BODY='No review here.' "$GUARD" >/dev/null || fail "docs-only diff refused"
-echo "ok 3 - docs-only diff without section is exempt"
+echo "ok 4 - docs-only diff without section is exempt"
 
-# 4. RED: one code file among docs revokes the exemption
+# 5. RED: one code file among docs revokes the exemption
 set +e
 printf '%s\n' "README.md" "report.py" \
   | PR_BODY='No review here.' "$GUARD" >/dev/null 2>&1 && fail "mixed diff passed"
 set -e
-echo "ok 4 - mixed diff without section fails"
+echo "ok 5 - mixed diff without section fails"
 
-# 5. RED: "rounds: 1" is not "rounds: 2"; nor is "rounds: 12"
+# 6. RED: wrong round counts — 1, 12, 2+, 2.5 (codex round 1, P2)
 for bad in \
   '## AI review — rounds: 1, engine: codex, verdict: pass' \
-  '## AI review — rounds: 12, engine: codex, verdict: pass'; do
+  '## AI review — rounds: 12, engine: codex, verdict: pass' \
+  '## AI review — rounds: 2+, engine: codex, verdict: pass' \
+  '## AI review — rounds: 2.5, engine: codex, verdict: pass'; do
   set +e
-  printf 'report.py\n' | PR_BODY="$bad" "$GUARD" >/dev/null 2>&1 \
+  printf 'convert.py\n' | PR_BODY="$bad" "$GUARD" >/dev/null 2>&1 \
     && fail "wrong round count passed: $bad"
   set -e
 done
-echo "ok 5 - rounds: 1 / rounds: 12 fail"
+echo "ok 6 - rounds: 1 / 12 / 2+ / 2.5 all fail"
 
-# 6. RED: section + rounds present but no verdict word
+# 7. RED: no engine named — the record can't support the spot audit
+#    (codex round 1, P1)
 set +e
-printf 'report.py\n' \
+printf 'convert.py\n' \
+  | PR_BODY='## AI review — rounds: 2, verdict: pass' "$GUARD" >/dev/null 2>&1 \
+  && fail "engine-less body passed"
+set -e
+echo "ok 7 - section without an engine fails"
+
+# 8. RED: section + rounds + engine present but no verdict word
+set +e
+printf 'convert.py\n' \
   | PR_BODY='## AI review — rounds: 2, engine: codex' "$GUARD" >/dev/null 2>&1 \
   && fail "verdict-less body passed"
 set -e
-echo "ok 6 - section without a verdict fails"
+echo "ok 8 - section without a verdict fails"
 
-# 7. GREEN: lenient formatting — lowercase heading, colon-less punctuation
-printf 'report.py\n' \
+# 9. RED: rename laundering — report.py renamed to docs/report.md; the
+#    workflow feeds BOTH sides, and the old side must revoke the exemption
+#    (codex round 1, P2)
+set +e
+printf '%s\n' "docs/report.md" "report.py" \
+  | PR_BODY='No review.' "$GUARD" >/dev/null 2>&1 && fail "rename into docs/ passed"
+set -e
+echo "ok 9 - rename old-side path (report.py -> docs/report.md) revokes exemption"
+
+# 10. GREEN: lenient formatting — lowercase heading, fields on separate lines
+printf 'convert.py\n' \
   | PR_BODY='## ai review
 rounds: 2 (codex round 1 found, round 2 verified)
+engine: codex
 verdict: pass' "$GUARD" >/dev/null || fail "leniently-formatted body refused"
-echo "ok 7 - lenient formatting still passes"
+echo "ok 10 - lenient formatting still passes"
 
-# 8. GREEN: empty diff passes
+# 11. GREEN: empty diff passes
 printf '' | PR_BODY='' "$GUARD" >/dev/null || fail "empty diff refused"
-echo "ok 8 - empty diff passes"
+echo "ok 11 - empty diff passes"
 
 echo "PASS check-ai-review"


### PR DESCRIPTION
## What

Mechanical enforcement for the different-model review gate (wiki-reliability Phase 4.2; ruling: `management-craft/docs/2B-PROJECTS/wiki-reliability/v1/RESEARCH.md` § 9.2; written rule already in `~/.claude/CLAUDE.md` § "Different-model review gate"). Twin of mc-wiki PR #66.

- `.github/workflows/ai-review-gate.yml` — on `pull_request_target` (opened/edited/reopened/synchronize), lists changed files via the API (no checkout of anything, ever — head content must never execute under `pull_request_target`), base64-encodes each path so a newline-bearing filename can't split or inject lines, feeds renames on both sides, and fails closed on a truncated listing (3,000-entry API cap). The predicate script is fetched from the **base** branch only.
- `scripts/ci/check-ai-review.sh` — the standalone predicate. Narrow exemption (everything in this repo is conversion code): only `*.md` under `docs/` plus root-level `*.md`, CLAUDE.md excluded. Field checks run inside ONE extracted, comment-stripped, boundary-checked `## AI review` section and require real bounded values: `rounds: 2` exactly, a non-empty engine, a non-empty verdict. No pipeline in the predicate can be SIGPIPE-killed by its own plumbing.
- `scripts/ci/check-ai-review.test.sh` — red/green per verification-gate-symmetry, 18 cases, all passing locally.

## Bootstrap note

Under `pull_request_target` the workflow runs the **base** branch's definition — deliberately, so a PR can't replace its own gate with unconditional success. Consequence: this bootstrap PR's own run validated under the earlier `pull_request` revision; the hardened version only takes effect **after this PR merges**. First post-merge PR should confirm the check fires.

## AI review — rounds: 2, engine: codex, verdict: PASS

Round 1 (direct, found): 3 P2 — same-line `<!-- -->` spans not stripped; empty field value consuming the next label (`engine:,verdict:pass`); `rounds: 2.foo` accepted. Fixed in f320613. Round 2 (verify, found): 1 P1 — newline-in-filename bypass of the line-oriented path hand-off; 3 P2 — labels matching inside larger words, loose heading boundaries both ends, SIGPIPE-killable plumbing. Fixed in 2c0c1a1. Exactly two rounds; review closed. (Preceded by the mirrored mc-wiki two-round review: 828ce84 + ed28742.)

## Branch protection

A workflow alone only **reports** — a red check does not block merge unless it's marked required in branch protection. **sourceconvert currently has no branch protection** (`gh api repos/AndySparks/sourceconvert/branches/main/protection` → 404 "Branch not protected"). The repo is public, so protection IS available — recommended one-click setup after this merges and the check has run once: Settings → Branches → add rule for `main` → Require status checks to pass → select `AI review gate / check`.
