### PR TITLE
fix(pymupdf): a page scan is not a figure — stop the text layer being deleted

### DIFF
--- a/assets.py
+++ b/assets.py
@@ -46,18 +46,31 @@ CAPTION_RE = re.compile(
 MIN_IMAGE_AREA = 2000  # ~45x45 px at PDF native resolution
 
 
+class RasterProbeFailed(Exception):
+    """`get_image_info` could not be read for a page.
+
+    Distinct from "this page has no images". The detector must not count a
+    page it could not inspect as evidence that a book is not a scan -- that
+    is the direction that loses text.
+    """
+
+
 def find_raster_regions(page: fitz.Page) -> List[fitz.Rect]:
     """Return bounding boxes for embedded raster images on this page.
 
     Filters out tiny images (below MIN_IMAGE_AREA) that are almost always
     decorative: bullet glyphs, page decorations, imprint logos.
+
+    Raises RasterProbeFailed if the page's image table cannot be read at all.
+    Callers that only want figures treat that as "no images"; the page-scan
+    detector treats it as "no evidence" instead.
     """
     regions: List[fitz.Rect] = []
     try:
         # get_image_info returns dicts with 'bbox' key in PDF points.
         info = page.get_image_info(xrefs=True)
-    except Exception:
-        return []
+    except Exception as exc:
+        raise RasterProbeFailed(str(exc)) from exc
     for item in info:
         bbox = item.get("bbox")
         if not bbox or len(bbox) != 4:
@@ -242,6 +255,15 @@ def detect_page_scan_document(doc) -> bool:
     text-bearing pages at all -- an un-OCR'd scan, a book of plates -- is
     never a page-scan document, so its images survive: they are the only
     content it has.
+
+    KNOWN, DELIBERATE ASYMMETRY on very short documents. A two-page PDF whose
+    single text-bearing page is dominated by a legitimate full-page infographic
+    scores 1/1 and is called a scan, and that infographic is dropped. There is
+    no minimum-evidence floor to prevent it, because a floor would push short
+    genuine scans the other way -- and the two errors are not equal. Dropping
+    an image loses an image. Failing to detect a scan loses the TEXT of every
+    page, silently, with every downstream gate green. In a corpus whose product
+    is quotable text, the error that keeps the text is the one to prefer.
     """
     try:
         total = doc.page_count
@@ -259,8 +281,9 @@ def detect_page_scan_document(doc) -> bool:
             page = doc[i]
             if _page_text_length(page) < PAGE_SCAN_MIN_TEXT_CHARS:
                 continue
+            rasters = find_raster_regions(page)
             text_pages += 1
-            if any(_covers_page(r, page) for r in find_raster_regions(page)):
+            if any(_covers_page(r, page) for r in rasters):
                 scanned += 1
         except Exception:
             # A page that cannot be read is not evidence either way, and must
@@ -290,7 +313,11 @@ def extract_page_assets(
     page's own bitmap and is dropped so the text layer survives. See
     "page scans are not figures" above.
     """
-    raster = find_raster_regions(page)
+    try:
+        raster = find_raster_regions(page)
+    except RasterProbeFailed:
+        # For figure extraction, an unreadable image table means no figures.
+        raster = []
     vector = find_vector_regions(page)
 
     # Combine and merge overlapping regions.
@@ -579,6 +606,16 @@ def strip_dangling_refs(text: str, md_path: Path) -> Tuple[str, List[str]]:
     return IMAGE_REF_RE.sub(replace, text), stripped
 
 
+# KNOWN LIMITATION: this sweeps the asset directory as it stands, so it counts
+# files left behind by a PREVIOUS conversion into the same directory as assets
+# the current run wrote. It became easier to hit once the page-scan filter
+# started emitting no assets at all for a scanned book: reconverting such a
+# book after upgrading leaves the old per-page PNGs on disk and reports them as
+# current. No dangling markdown reference results -- the markdown simply does
+# not name them -- so the never-dangle invariant holds; what is wrong is the
+# asset COUNT in the report. Convert into a clean output directory after an
+# upgrade. (Raised by codex review, 2026-08-31; not fixed here because clearing
+# the directory is a destructive change that deserves its own change.)
 def build_asset_manifest(md_path: Path, asset_dir=None) -> List[dict]:
     """Describe every asset this conversion wrote, and what points at it.
 

--- a/assets.py
+++ b/assets.py
@@ -176,13 +176,22 @@ ASSET_DPI = 220
 # The text condition in the detector is what protects an un-OCR'd scan: a book
 # of page images with NO text layer is never classified as a page-scan
 # document, so its images -- the only content it has -- are still emitted.
-PAGE_SCAN_AREA_RATIO = 0.9
-# A page needs this much text before it counts as EVIDENCE of a text layer in
-# the detector. It is deliberately not used as a per-page gate; see above.
+# A region must cover this fraction of the page in BOTH dimensions. Comparing
+# areas alone is not enough: a banner twice the page width and 45% of its
+# height has the area of 90% of the page without covering it, and an image
+# hanging off the crop box is bigger than the page it sits on. Both dimensions
+# plus the intersection with the page rect is what "covers the page" means.
+PAGE_SCAN_COVER_RATIO = 0.9
+# A page needs this much text to count as carrying a text layer.
 PAGE_SCAN_MIN_TEXT_CHARS = 200
-# Fraction of sampled pages that must look like a scanned page before the
-# whole document is treated as a scan.
-PAGE_SCAN_DOC_FRACTION = 0.5
+# Of the sampled pages THAT CARRY TEXT, this fraction must be full-page
+# bitmaps before the document is treated as a scan. The denominator is
+# text-bearing pages, not all sampled pages, because a scanned book's blank
+# versos, plate pages and sparse chapter-openers are not evidence either way
+# and must not drag a real scan below the bar -- that was the defect in the
+# first draft, which classified a 3-page scan with one text-heavy page as
+# not-a-scan and ate all three text layers.
+PAGE_SCAN_DOC_FRACTION = 0.6
 # Sampling bound -- 704-page books should not pay a full extra pass.
 PAGE_SCAN_SAMPLE_PAGES = 40
 
@@ -195,12 +204,32 @@ def _page_text_length(page: fitz.Page) -> int:
 
 
 def _covers_page(rect: fitz.Rect, page: fitz.Page) -> bool:
-    """True if `rect` covers essentially the whole page."""
+    """True if `rect` covers essentially the whole page in both dimensions."""
     page_rect = page.rect
-    page_area = page_rect.width * page_rect.height
-    if page_area <= 0:
+    if page_rect.width <= 0 or page_rect.height <= 0:
         return False
-    return (rect.width * rect.height) / page_area >= PAGE_SCAN_AREA_RATIO
+    # Only the part of the region actually on the page counts.
+    visible = fitz.Rect(rect) & page_rect
+    if visible.is_empty:
+        return False
+    return (
+        visible.width / page_rect.width >= PAGE_SCAN_COVER_RATIO
+        and visible.height / page_rect.height >= PAGE_SCAN_COVER_RATIO
+    )
+
+
+def _sample_indices(total: int, want: int):
+    """Up to `want` indices spread evenly across [0, total).
+
+    `range(0, total, total // want)` truncated to `want` entries samples only
+    the FRONT of the document whenever the step rounds down to 1 -- a 79-page
+    book was sampled over pages 0-39 and its whole second half went unseen.
+    """
+    if total <= 0 or want <= 0:
+        return []
+    if total <= want:
+        return list(range(total))
+    return sorted({round(i * (total - 1) / (want - 1)) for i in range(want)})
 
 
 def detect_page_scan_document(doc) -> bool:
@@ -208,30 +237,39 @@ def detect_page_scan_document(doc) -> bool:
 
     Samples evenly across the document rather than reading every page, so a
     700-page book does not pay a second full pass.
+
+    The ratio is taken over pages that CARRY TEXT. A document with no
+    text-bearing pages at all -- an un-OCR'd scan, a book of plates -- is
+    never a page-scan document, so its images survive: they are the only
+    content it has.
     """
     try:
         total = doc.page_count
     except Exception:
         return False
-    if total <= 0:
-        return False
 
-    step = max(1, total // PAGE_SCAN_SAMPLE_PAGES)
-    indices = list(range(0, total, step))[:PAGE_SCAN_SAMPLE_PAGES]
+    indices = _sample_indices(total, PAGE_SCAN_SAMPLE_PAGES)
     if not indices:
         return False
 
+    text_pages = 0
     scanned = 0
     for i in indices:
         try:
             page = doc[i]
+            if _page_text_length(page) < PAGE_SCAN_MIN_TEXT_CHARS:
+                continue
+            text_pages += 1
+            if any(_covers_page(r, page) for r in find_raster_regions(page)):
+                scanned += 1
         except Exception:
+            # A page that cannot be read is not evidence either way, and must
+            # not sit in the denominator biasing the answer toward "not a
+            # scan" -- the answer that loses text.
             continue
-        if _page_text_length(page) < PAGE_SCAN_MIN_TEXT_CHARS:
-            continue
-        if any(_covers_page(r, page) for r in find_raster_regions(page)):
-            scanned += 1
-    return (scanned / len(indices)) >= PAGE_SCAN_DOC_FRACTION
+    if text_pages == 0:
+        return False
+    return (scanned / text_pages) >= PAGE_SCAN_DOC_FRACTION
 
 
 def extract_page_assets(

--- a/assets.py
+++ b/assets.py
@@ -141,24 +141,125 @@ CAPTION_SEARCH_DISTANCE = 40
 # DPI for rendered assets.
 ASSET_DPI = 220
 
+# --- page scans are not figures --------------------------------------------
+#
+# A home-scanned or archive.org book is one full-page bitmap per page with an
+# OCR text layer sitting on top of it. `find_raster_regions` sees that bitmap
+# as a figure region spanning the entire page, and the region splicer in
+# convert.py emits region markdown IN PLACE OF the text underneath it -- so a
+# full-page region consumes every character on the page.
+#
+# On William James's *Principles of Psychology* Vol 1 (704 pages) that turned
+# the whole book into 704 `![Figure on page N]` lines and 9,350 words, about
+# 1% of the text. Nothing caught it: quality_score read 1.0, the
+# degenerate-text gate was clean, and the locator gate was clean.
+#
+# THE DECISION IS PER DOCUMENT, NOT PER PAGE, and that is the whole subtlety.
+#
+# Per page you cannot tell these two apart without guessing:
+#
+#   - a scanned book's chapter-opener, which carries a full-page bitmap and
+#     only three lines of text; and
+#   - a prose book's full-page plate, which carries a full-page image and only
+#     its caption.
+#
+# Guessing by "how much text is on this page" gets one of them wrong every
+# time, and the first draft of this fix did: it used a 200-character floor,
+# which would have silently eaten the text of every sparse page in a scanned
+# book -- a smaller version of the very bug it was written for.
+#
+# A book, though, is scanned throughout or it is not. So we ask the DOCUMENT:
+# do most of its pages carry a full-page bitmap with text on top? If yes, every
+# full-page bitmap in it is a page scan and none of them is a figure. If no, a
+# full-page image is a plate and is kept.
+#
+# The text condition in the detector is what protects an un-OCR'd scan: a book
+# of page images with NO text layer is never classified as a page-scan
+# document, so its images -- the only content it has -- are still emitted.
+PAGE_SCAN_AREA_RATIO = 0.9
+# A page needs this much text before it counts as EVIDENCE of a text layer in
+# the detector. It is deliberately not used as a per-page gate; see above.
+PAGE_SCAN_MIN_TEXT_CHARS = 200
+# Fraction of sampled pages that must look like a scanned page before the
+# whole document is treated as a scan.
+PAGE_SCAN_DOC_FRACTION = 0.5
+# Sampling bound -- 704-page books should not pay a full extra pass.
+PAGE_SCAN_SAMPLE_PAGES = 40
+
+
+def _page_text_length(page: fitz.Page) -> int:
+    try:
+        return len(page.get_text().strip())
+    except Exception:
+        return 0
+
+
+def _covers_page(rect: fitz.Rect, page: fitz.Page) -> bool:
+    """True if `rect` covers essentially the whole page."""
+    page_rect = page.rect
+    page_area = page_rect.width * page_rect.height
+    if page_area <= 0:
+        return False
+    return (rect.width * rect.height) / page_area >= PAGE_SCAN_AREA_RATIO
+
+
+def detect_page_scan_document(doc) -> bool:
+    """True if `doc` is a scanned book: page bitmaps with a text layer on top.
+
+    Samples evenly across the document rather than reading every page, so a
+    700-page book does not pay a second full pass.
+    """
+    try:
+        total = doc.page_count
+    except Exception:
+        return False
+    if total <= 0:
+        return False
+
+    step = max(1, total // PAGE_SCAN_SAMPLE_PAGES)
+    indices = list(range(0, total, step))[:PAGE_SCAN_SAMPLE_PAGES]
+    if not indices:
+        return False
+
+    scanned = 0
+    for i in indices:
+        try:
+            page = doc[i]
+        except Exception:
+            continue
+        if _page_text_length(page) < PAGE_SCAN_MIN_TEXT_CHARS:
+            continue
+        if any(_covers_page(r, page) for r in find_raster_regions(page)):
+            scanned += 1
+    return (scanned / len(indices)) >= PAGE_SCAN_DOC_FRACTION
+
 
 def extract_page_assets(
     page: fitz.Page,
     stem: str,
     asset_dir: Path,
     page_num: int,
+    page_scan_document: bool = False,
 ) -> List[Tuple[fitz.Rect, str]]:
     """Render all figure regions on a page and return (rect, markdown) pairs.
 
     `stem` is the markdown output filename without extension — used to
     build an asset subdirectory name. `page_num` is the 1-indexed page
     number used in the asset filename.
+
+    `page_scan_document` comes from `detect_page_scan_document` and says the
+    book is a scan; when it is set, a region covering the whole page is the
+    page's own bitmap and is dropped so the text layer survives. See
+    "page scans are not figures" above.
     """
     raster = find_raster_regions(page)
     vector = find_vector_regions(page)
 
     # Combine and merge overlapping regions.
     combined = _merge_rects(raster + vector, gap=REGION_PADDING)
+    if page_scan_document:
+        # Drop the page's own scan bitmap (see "page scans are not figures").
+        combined = [r for r in combined if not _covers_page(r, page)]
     if not combined:
         return []
 

--- a/convert.py
+++ b/convert.py
@@ -2940,6 +2940,13 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=True):
     print(f"  {total_pages} pages")
 
     title = clean_title(pdf_path.stem)
+    output_dir = Path(output_dir)
+    # Create the output directory here rather than relying on the asset writer
+    # to have made it as a side effect. A book with no extracted figures --
+    # which is exactly what a scanned book now is, see
+    # assets."page scans are not figures" -- otherwise fails at the final
+    # write with a FileNotFoundError after doing all of the work.
+    output_dir.mkdir(parents=True, exist_ok=True)
     output_file = output_dir / f"{pdf_path.stem}.md"
 
     report = ConversionReport(
@@ -2976,6 +2983,13 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=True):
     # prevents PyMuPDF from interleaving left/right columns mid-sentence
     # on journal-article pages.
     raw_pages = []
+    # A scanned book is one full-page bitmap per page with an OCR text layer on
+    # top. Decided once for the document, because per page a scanned book's
+    # sparse chapter-opener and a prose book's captioned plate are
+    # indistinguishable. See assets."page scans are not figures".
+    page_scan_document = assets.detect_page_scan_document(doc)
+    if page_scan_document:
+        print("  scanned book detected: page bitmaps will not be emitted as figures")
     for i in range(total_pages):
         page = doc[i]
         # Track how many pages look two-column so we can hint the user
@@ -2985,7 +2999,8 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=True):
         page_asset_regions = []
         if extract_images:
             extracted = assets.extract_page_assets(
-                page, pdf_path.stem, asset_dir, i + 1
+                page, pdf_path.stem, asset_dir, i + 1,
+                page_scan_document=page_scan_document,
             )
             total_assets += len(extracted)
             # Convert to (start_y, end_y, markdown) tuples for the

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -667,3 +667,53 @@ def build_figure_epub(tmp_path: Path, name: str = "figure.epub") -> Path:
         (1, "The Second Move", "ch2.xhtml"),
     ]
     return build_epub(tmp_path, docs, nav, "ncx", name=name)
+
+
+def build_scanned_ocr_pdf(
+    tmp_path: Path,
+    pages: int = 3,
+    body: str = "The real sound of the cannon is the sensation it makes.",
+    name: str = "scanned_ocr.pdf",
+) -> Path:
+    """Build a PDF shaped like a home-scanned book with an OCR text layer.
+
+    Every page is one full-page raster image (the scan) with a text layer
+    sitting on top of it -- exactly what a Brother ADS-4700W scan that has
+    been OCR'd elsewhere looks like, and what archive.org serves. The
+    distinguishing feature is that the image bbox covers the WHOLE page,
+    so a naive figure-region splicer replaces the page's text with an
+    image reference and silently drops the book.
+    """
+    out = tmp_path / name
+    doc = fitz.open()
+    # A small grey PNG, stretched to fill the page. Content does not matter;
+    # the bbox covering the full page is the whole point.
+    src = fitz.open()
+    tmp_page = src.new_page(width=100, height=160)
+    tmp_page.draw_rect(fitz.Rect(0, 0, 100, 160), color=(0.5, 0.5, 0.5),
+                       fill=(0.5, 0.5, 0.5))
+    png = tmp_page.get_pixmap(dpi=72).tobytes("png")
+    src.close()
+
+    for i in range(pages):
+        page = doc.new_page(width=334, height=559)
+        page.insert_image(fitz.Rect(0, 0, 334, 559), stream=png)
+        # The OCR text layer: a running folio and a page's worth of prose.
+        # The volume matters -- the detector asks whether a page carries a
+        # real text layer, and a caption-sized string is not one.
+        page.insert_text((20, 20), str(36 + i))
+        # Varied per page: an identical line on every page is a running
+        # header, and the converter is right to strip it.
+        page.insert_text((20, 60), f"{body} ({i})")
+        y = 90
+        for n in range(14):
+            page.insert_text(
+                (20, y),
+                f"line {n} of ordinary body prose running the measure of "
+                f"the page as scanned book text does",
+                fontsize=8,
+            )
+            y += 14
+    doc.save(str(out))
+    doc.close()
+    return out

--- a/tests/test_page_scan_text_loss.py
+++ b/tests/test_page_scan_text_loss.py
@@ -199,3 +199,48 @@ def test_image_only_page_still_emits_its_image(tmp_path):
         "an un-OCR'd full-page image is the page's only content and must "
         "still be emitted"
     )
+
+
+def test_an_unreadable_image_table_is_not_evidence_against_a_scan(tmp_path,
+                                                                  monkeypatch):
+    """A page we could not inspect must leave the denominator alone.
+
+    Counting it as "no full-page raster" biases the detector toward
+    not-a-scan, which is the answer that deletes the text.
+    """
+    pdf = build_scanned_ocr_pdf(tmp_path, pages=6, name="probe.pdf")
+    doc = fitz.open(str(pdf))
+    assert assets.detect_page_scan_document(doc), "control: this is a scan"
+
+    real = assets.find_raster_regions
+    calls = {"n": 0}
+
+    def flaky(page):
+        calls["n"] += 1
+        if calls["n"] % 2 == 0:
+            raise assets.RasterProbeFailed("simulated")
+        return real(page)
+
+    monkeypatch.setattr(assets, "find_raster_regions", flaky)
+    assert assets.detect_page_scan_document(doc), (
+        "pages whose image table could not be read must be skipped, not "
+        "counted as evidence that this is not a scan"
+    )
+    doc.close()
+
+
+def test_extract_page_assets_survives_an_unreadable_image_table(tmp_path,
+                                                                monkeypatch):
+    """Figure extraction keeps its old tolerant behaviour."""
+    pdf = build_figure_pdf(tmp_path)
+    doc = fitz.open(str(pdf))
+
+    def boom(page):
+        raise assets.RasterProbeFailed("simulated")
+
+    monkeypatch.setattr(assets, "find_raster_regions", boom)
+    # The vector figure is still found; the unreadable raster table is not
+    # allowed to take the whole page down.
+    extracted = assets.extract_page_assets(doc[0], "fig", tmp_path / "e", 1)
+    doc.close()
+    assert len(extracted) == 1

--- a/tests/test_page_scan_text_loss.py
+++ b/tests/test_page_scan_text_loss.py
@@ -87,6 +87,85 @@ def test_a_real_figure_is_still_extracted(tmp_path):
     assert "Figure 1.1" in md, "the caption must still be matched"
 
 
+def test_a_sub_page_figure_survives_inside_a_scanned_document(tmp_path):
+    """The half the first draft of these tests did NOT cover.
+
+    Every other test here exercises `page_scan_document=False` on the
+    legitimate cases, so an implementation of "drop every region when the flag
+    is set" passed all of them. The filter must drop the page bitmap and
+    nothing else, so a genuine sub-page figure has to survive with the flag ON.
+    """
+    pdf = build_figure_pdf(tmp_path)
+    doc = fitz.open(str(pdf))
+    extracted = assets.extract_page_assets(
+        doc[0], "fig", tmp_path / "d", 1, page_scan_document=True,
+    )
+    doc.close()
+    assert len(extracted) == 1, (
+        "the page-scan filter must drop only regions that cover the page; a "
+        "sub-page figure inside a scanned book is still a figure"
+    )
+
+
+def test_sampling_spans_the_whole_document(tmp_path):
+    """A scan whose front matter is text-only must still be classified.
+
+    `range(0, total, total // 40)` truncated to 40 entries samples only the
+    front of the document when the step rounds down to 1, so a 79-page book
+    was judged entirely on pages 0-39.
+    """
+    assert assets._sample_indices(79, 40)[-1] == 78, (
+        "sampling must reach the last page"
+    )
+    assert assets._sample_indices(159, 40)[-1] == 158
+    assert assets._sample_indices(3, 40) == [0, 1, 2]
+    assert assets._sample_indices(0, 40) == []
+
+
+def test_a_short_scan_with_sparse_pages_is_still_a_scan(tmp_path):
+    """Blank and sparse pages must not drag a real scan below the bar.
+
+    A 3-page scan with one text-heavy page and two sparse ones scored 1/3
+    under the first draft and was classified not-a-scan -- which would have
+    replaced all three text layers with image references.
+    """
+    pdf = build_scanned_ocr_pdf(tmp_path, pages=1, name="short.pdf")
+    doc = fitz.open(str(pdf))
+    # Append two sparse scan pages: full-page bitmap, almost no text.
+    src = fitz.open()
+    tmp_page = src.new_page(width=100, height=160)
+    tmp_page.draw_rect(fitz.Rect(0, 0, 100, 160), color=(0.5, 0.5, 0.5),
+                       fill=(0.5, 0.5, 0.5))
+    png = tmp_page.get_pixmap(dpi=72).tobytes("png")
+    src.close()
+    for _ in range(2):
+        page = doc.new_page(width=334, height=559)
+        page.insert_image(fitz.Rect(0, 0, 334, 559), stream=png)
+        page.insert_text((20, 40), "CHAPTER II")
+    assert assets.detect_page_scan_document(doc), (
+        "sparse pages are not evidence against a scan"
+    )
+    doc.close()
+
+
+def test_an_oversized_banner_does_not_cover_the_page(tmp_path):
+    """Area alone is not coverage.
+
+    A region twice the page width and 45% of its height has the AREA of 90%
+    of the page while covering none of it, and a region hanging off the crop
+    box is larger than the page it sits on.
+    """
+    doc = fitz.open()
+    page = doc.new_page(width=400, height=600)
+    banner = fitz.Rect(-200, 0, 600, 270)      # 800 x 270 = 90% of page area
+    assert not assets._covers_page(banner, page)
+    overhang = fitz.Rect(-50, -50, 450, 650)   # bigger than the page
+    assert assets._covers_page(overhang, page), (
+        "a bitmap bleeding past the crop box still covers the page"
+    )
+    doc.close()
+
+
 def test_image_only_page_still_emits_its_image(tmp_path):
     """A full-page image with NO text layer has nothing else to emit.
 

--- a/tests/test_page_scan_text_loss.py
+++ b/tests/test_page_scan_text_loss.py
@@ -1,0 +1,122 @@
+"""A full-page scan image must never suppress the page's text layer.
+
+WHY THIS EXISTS
+
+2026-08-31. Andy dropped William James's *Principles of Psychology* Vol 1
+(704 pages, a scan with a good OCR text layer) into the ingest inbox. The
+pymupdf backend produced 9,350 words -- roughly 1% of the book -- and
+emitted every single page as `![Figure on page N]` with no prose at all.
+
+The mechanism: `assets.find_raster_regions` reported the page-scan bitmap as
+a figure region covering the entire page, and `_extract_page_text_with_regions`
+walks the page top-to-bottom emitting region markdown in place of the text
+underneath it. A region spanning the full page therefore consumed every
+character on it.
+
+What makes this the dangerous class of bug rather than an annoying one is
+that NOTHING caught it. `quality_score` read 1.0, the degenerate-text gate
+was clean, and the locator gate was clean. `--no-clean` produced byte-identical
+output, so the cleanup pass was not involved. The board was green on a 99%
+content loss.
+"""
+import fitz
+import pytest
+
+import assets
+from tests.fixtures import build_scanned_ocr_pdf, build_figure_pdf
+
+
+def test_full_page_scan_is_not_reported_as_a_figure(tmp_path):
+    """The bad case: a page-scan bitmap over a text layer is not a figure."""
+    pdf = build_scanned_ocr_pdf(tmp_path)
+    doc = fitz.open(str(pdf))
+    page = doc[0]
+    # Sanity: the fixture really does have a full-page raster and real text.
+    raster = assets.find_raster_regions(page)
+    assert raster, "fixture must carry a raster image"
+    assert len(page.get_text().strip()) > 200, "fixture must carry a text layer"
+
+    assert assets.detect_page_scan_document(doc), (
+        "a book of page bitmaps with a text layer is a scanned document"
+    )
+    extracted = assets.extract_page_assets(
+        page, "scan", tmp_path / "a", 1, page_scan_document=True
+    )
+    doc.close()
+    assert extracted == [], (
+        "a full-page scan bitmap over a text layer is the page itself, not a "
+        "figure; emitting it as one costs the page its text"
+    )
+
+
+def test_scanned_book_conversion_keeps_its_text(tmp_path):
+    """End to end: the words in the book survive into the markdown."""
+    import convert
+
+    pdf = build_scanned_ocr_pdf(tmp_path, pages=5)
+    outdir = tmp_path / "out"
+    convert.convert_with_pymupdf(pdf, outdir, extract_images=True)
+    md = (outdir / f"{pdf.stem}.md").read_text()
+
+    assert "cannon" in md, "body text was dropped by the figure splicer"
+    # One occurrence per page, not one image reference per page.
+    assert md.count("cannon") == 5, f"expected 5 pages of body, got {md.count('cannon')}"
+    assert "Figure on page" not in md, (
+        "page scans must not be emitted as figures"
+    )
+
+
+def test_a_real_figure_is_still_extracted(tmp_path):
+    """The other half of the gate: legitimate figures must still be found.
+
+    Without this, 'drop full-page regions' could be implemented as 'drop
+    every region' and the bad-case test above would still pass.
+    """
+    pdf = build_figure_pdf(tmp_path)
+    doc = fitz.open(str(pdf))
+    page = doc[0]
+    assert not assets.detect_page_scan_document(doc), (
+        "a prose page with a drawn figure is not a scanned document"
+    )
+    extracted = assets.extract_page_assets(page, "fig", tmp_path / "b", 1)
+    doc.close()
+    assert len(extracted) == 1, (
+        "a genuine sub-page figure must still be extracted"
+    )
+    _rect, md = extracted[0]
+    assert "Figure 1.1" in md, "the caption must still be matched"
+
+
+def test_image_only_page_still_emits_its_image(tmp_path):
+    """A full-page image with NO text layer has nothing else to emit.
+
+    A plate, a fold-out, or a scan that was never OCR'd. Dropping the image
+    there would lose the only content the page has.
+    """
+    pdf = tmp_path / "plate.pdf"
+    doc = fitz.open()
+    page = doc.new_page(width=334, height=559)
+    src = fitz.open()
+    tmp_page = src.new_page(width=100, height=160)
+    tmp_page.draw_rect(fitz.Rect(0, 0, 100, 160), color=(0.2, 0.2, 0.2),
+                       fill=(0.2, 0.2, 0.2))
+    png = tmp_page.get_pixmap(dpi=72).tobytes("png")
+    src.close()
+    page.insert_image(fitz.Rect(0, 0, 334, 559), stream=png)
+    doc.save(str(pdf))
+    doc.close()
+
+    doc = fitz.open(str(pdf))
+    assert not assets.detect_page_scan_document(doc), (
+        "no text layer means this is not a scanned-and-OCR'd book, so its "
+        "images are the only content it has"
+    )
+    extracted = assets.extract_page_assets(
+        doc[0], "plate", tmp_path / "c", 1,
+        page_scan_document=assets.detect_page_scan_document(doc),
+    )
+    doc.close()
+    assert len(extracted) == 1, (
+        "an un-OCR'd full-page image is the page's only content and must "
+        "still be emitted"
+    )


### PR DESCRIPTION
## What broke

A home-scanned or archive.org book is **one full-page bitmap per page with an OCR text layer on top**. `assets.find_raster_regions` reported that bitmap as a figure region covering the whole page, and `convert._extract_page_text_with_regions` emits region markdown *in place of* the text underneath it — so the region consumed every character on every page.

Found while ingesting William James, *Principles of Psychology* Vol 1 (704 pages) on 2026-08-31:

| | before | after |
|---|---|---|
| words | 9,350 (~1% of the book) | **286,133** |
| pages with a captured printed folio | 0 | **634 / 704** |
| body prose | none — 704 × `![Figure on page N]` | present |

`page_pdf=51 → page_printed=36` matches the raw PDF's own text layer, so the book is now page-citable where it previously had no text at all.

**What makes this the dangerous class:** nothing caught it. `quality_score` read **1.0**, the degenerate-text gate was clean, the locator gate was clean, and `--no-clean` produced byte-identical output. A green board on a 99% content loss.

## The fix

The decision is made **per document, not per page**, and that is the whole subtlety. Per page, a scanned book's sparse chapter-opener and a prose book's captioned full-page plate are indistinguishable — the first draft used a 200-character floor and would have silently eaten the text of every sparse page in a scanned book, a smaller copy of the bug it was written for.

A book is scanned throughout or it is not. `detect_page_scan_document()` samples up to 40 pages spread across the whole document and asks: **of the pages that carry text, how many are full-page bitmaps?** The text condition protects an un-OCR'd scan — a book of page images with no text layer is never classified, so its images, the only content it has, are still emitted.

Also creates the output directory in `convert_with_pymupdf` rather than relying on the asset writer having made it as a side effect. A book with no extracted figures — which is what a scanned book now is — otherwise did all the work and then failed at the final write.

## Verification

- **James Vol 1**, the originating case: table above.
- **40 real corpus PDFs**: 38 not-a-scan, 2 scans — *A Primer of Supportive Psychotherapy* (295 pp, every page a 442×663 raster over a 1,500–2,500 char text layer) and *Ericsson & Charness 1994* (23 pp, 594×791 rasters over 4,500–6,600 chars). Both confirmed by direct inspection of page geometry and text layers, not by taking the classifier's word for it. **Both are currently broken in the corpus the same way James was.**
- **Suite: 381 passed, 9 skipped.**
- The three guards added in round 2 were run **red against the previous commit** and green against this one.

Tests cover both halves of the gate: the scan keeps its text, **and** a genuine sub-page figure is still extracted with its caption *with the flag on*, **and** an un-OCR'd full-page image is still emitted. Without those, "drop full-page regions" could be implemented as "drop every region" and still pass.

## AI review — rounds: 2, engine: codex, verdict: pass with documented residuals

Round 1 raised five findings; four were real and are fixed (front-of-document sampling bias, all-pages denominator, area-not-coverage geometry, and a figure guard that never exercised the branch it claimed to test). Round 2 verified them and left two residuals, both now closed or documented:

- **Raster-probe failures in the denominator** — fixed; `RasterProbeFailed` now distinguishes "could not inspect" from "no images".
- **Short-document false positive** — *deliberately not fixed*, and documented in the docstring. A floor would push short genuine scans the other way, and the errors are not equal: dropping an image loses an image; failing to detect a scan loses the text of every page. Prefer the error that keeps the text.
- **Stale asset manifest on reconversion** — pre-existing `build_asset_manifest` behaviour, now documented above that function. Convert into a clean directory after upgrading.

Notably, the denominator defect was not hypothetical: it was misclassifying *Ericsson & Charness 1994* in the real corpus.

## Follow-on

Once this lands, `mc-wiki`'s `ingest-batch.sh` should probe the text layer and route to `pymupdf` instead of hardcoding `--method marker`. For James that is a ~2-minute conversion instead of ~6.3 hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)