### PR TITLE
fix: page_numbering: printed is a licence to cite — make it be earned

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ which you have:
 
 | `page_numbering` | Meaning | Backends |
 |---|---|---|
-| `printed` | Real page numbers were captured | `pymupdf` and `marker`, when printed page numbers were actually found |
-| `pdf_only` | PDF page index only | `pymupdf` / `marker` (no printed numbers found), `pymupdf4llm`, `ocr` |
+| `printed` | Real page numbers were captured **and they cohere** — a dominant page_pdf→page_printed offset carries at least half the captured folios | `pymupdf` and `marker`, when printed page numbers were found and agree with each other |
+| `pdf_only` | PDF page index only. Also the verdict when folios *were* captured but do not cohere at all (`page_printed_offset_support` below 0.5) — numbers that disagree with each other are not a pagination, and `page_printed_count` stays non-zero so that case is still visible | `pymupdf` / `marker` (no printed numbers found, or incoherent ones), `pymupdf4llm`, `ocr` |
 | `none` | No locators emitted at all | `pandoc` (EPUB — reflowable, no pages exist), `docling` |
 
 `pymupdf` and `marker` both decide between `printed` and `pdf_only` at runtime;

--- a/convert.py
+++ b/convert.py
@@ -1167,6 +1167,104 @@ BACKEND_PAGE_NUMBERING = {
 }
 
 
+# How much support the best offset needs before a book that FAILED the
+# consistency check may still be called page-citable.
+#
+# Chosen from the corpus, not tuned. Of the 22 conversions whose sidecars said
+# `page_numbering: printed` with `offset_consistent: false` on 2026-09-01, the
+# support for the dominant offset was: 3%, then 54, 57, 67, 75, 77, 79, 84,
+# 84%, and the rest refused for adjacent dissent having already cleared the 85%
+# bar. There is a 51-point gap between the first and the second. 0.5 sits in
+# it, and the rule it expresses is "the captured folios do not cohere AT ALL",
+# not "this book renumbers somewhere".
+_PAGE_NUMBERING_MIN_OFFSET_SUPPORT = 0.5
+
+
+def _page_offset_support(page_printed_by_pdf_index):
+    """Fraction of captured arabic folios carrying the best-supported offset.
+
+    Returns None when there are too few samples to speak of support at all.
+    `_dominant_page_offset` computes this number to decide consensus and then
+    discards it; the verdict needs it, so it is computed here rather than
+    parsed back out of the warning prose.
+    """
+    by_index = _page_offset_samples(page_printed_by_pdf_index)
+    if len(by_index) < _OFFSET_MIN_SAMPLES:
+        return None
+    counts = collections.Counter(by_index.values())
+    _, agreeing = counts.most_common(1)[0]
+    return agreeing / len(by_index)
+
+
+def _decide_page_numbering(captured, offset_consistent, offset_support=None):
+    """What kind of page address can this conversion honestly produce?
+
+    "printed" is a LICENCE: mc-wiki's `tools/cite.py` refuses to cite a source
+    by page unless this reads "printed", so the value decides whether page
+    numbers out of this book can reach a citation.
+
+    It used to be granted on `captured > 0` alone -- any folio anywhere earned
+    it, however incoherent the pagination. Found 2026-09-01 by the annotated
+    edition of *The Human Side of Enterprise*: 30 folios across 480 sheets
+    (coverage 0.062), the dominant offset carried by 1 of 30 (3%), and the
+    captured values reading sheet 56 -> "1", 72 -> "2", 85 -> "4", 99 -> "3".
+    Those are the annotated edition's MARGINAL ANNOTATION NUMBERS being read as
+    folios. Filing on that verdict would have manufactured the same
+    fabricated-page-number hazard that `thiel-zero-to-one` was stamped to
+    correct the same night, where a chapter cited at p. 154 begins at p. 118.
+
+    THE FIX IS DELIBERATELY NARROW, and the first draft of it was not. Refusing
+    every `offset_consistent: false` book would have demoted 22 sources,
+    including *The Achievement Motive* (340 folios, 89.5% coverage) and
+    *Scaling People* (99.2%). Those are not incoherent -- they renumber
+    somewhere, or carry two sequences, which is ordinary and which
+    `page_correspondence_checked` already exists to adjudicate. Only a book
+    whose folios agree with each other almost nowhere loses the licence.
+
+    `page_printed_count` and `page_printed_coverage` are untouched, so
+    "captured folios that do not cohere" stays readable as count > 0 with
+    numbering == "pdf_only".
+
+    THREE BOUNDARIES THIS DELIBERATELY DOES NOT CROSS. All three were raised in
+    review; each is recorded here rather than silently left, because the next
+    person to read this will have the same three questions.
+
+    1. Fewer than three captured folios keeps the old verdict (support is
+       None). With no derived offset nothing is interpolated -- the few
+       markers present are CAPTURED values, not manufactured ones -- so a
+       book with one real folio genuinely does carry one real page number.
+       Demoting on sparseness is a different judgement about a different
+       defect, and it would move four more corpus sources on a question this
+       change did not investigate.
+
+    2. Support is measured over the captured-folio population, which is not
+       identical to `page_printed_count` (that counts EMITTED locators, after
+       blank and broken-TOC pages are dropped). That is deliberate: support
+       exists to describe the same evidence `_derive_page_offset` judged, and
+       judging it against a different population would make the number
+       disagree with the decision it explains.
+
+    3. A global modal share is a blunt coherence test. A volume with three
+       equally-sized numbering sequences scores ~0.33 and is demoted. That is
+       the intended reading rather than a false positive: in such a volume
+       "p. 50" does not identify a page without naming the sequence, so it is
+       not citable by page number alone. `page_correspondence_checked` is the
+       human override for a book where that judgement is wrong.
+    """
+    if not captured:
+        return "pdf_only"
+    if offset_consistent:
+        return "printed"
+    # Inconsistent, but with too few samples to judge support: leave the
+    # existing verdict alone rather than widen this change into sparse-capture
+    # territory, which is a different defect.
+    if offset_support is None:
+        return "printed"
+    if offset_support < _PAGE_NUMBERING_MIN_OFFSET_SUPPORT:
+        return "pdf_only"
+    return "printed"
+
+
 def _apply_backend_page_numbering(report):
     """Stamp a backend's fixed locator capability onto its report.
 
@@ -3012,6 +3110,12 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=True):
         for page_pdf, _, page_printed in cleaned_pages if page_printed
     }
     page_printed_offset, page_printed_offset_consistent = _derive_page_offset(page_printed_by_pdf_index)
+    # Support is measured HERE, on the same samples _derive_page_offset just
+    # judged -- not later. The outlier sweep below deletes every capture that
+    # contradicts an adopted offset, so a support figure taken after it reads
+    # ~1.0 for any book that got one, which is both useless and a false
+    # description of the field. (codex round 1, P2)
+    page_printed_offset_support = _page_offset_support(page_printed_by_pdf_index)
     # Captured-but-contradicting folios are misreads, exactly as on the
     # marker path. Drop them so interpolation supplies the right number
     # instead of publishing a corrupted one with full confidence, and so
@@ -3143,7 +3247,10 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=True):
         report.page_printed_count / report.page_locator_count
         if report.page_locator_count else 0.0
     )
-    report.page_numbering = "printed" if report.page_printed_count else "pdf_only"
+    report.page_printed_offset_support = page_printed_offset_support
+    report.page_numbering = _decide_page_numbering(
+        report.page_printed_count, page_printed_offset_consistent,
+        page_printed_offset_support)
     report.page_printed_offset = page_printed_offset
     report.page_printed_offset_consistent = page_printed_offset_consistent
 
@@ -3234,6 +3341,10 @@ def _rewrite_marker_page_locators(target, report):
         return
 
     offset, offset_consistent = _derive_page_offset(page_printed_by_index)
+    # Same reason as the pymupdf path: measure support on the samples the
+    # offset decision just judged, before the outlier sweep below removes the
+    # dissenters and makes every surviving book look unanimous.
+    offset_support_at_derivation = _page_offset_support(page_printed_by_index)
     # Captured-but-contradicting folios are OCR misreads. Drop them so
     # interpolation can supply the right number, and so the span below is
     # not stretched by a corrupted sample.
@@ -3283,7 +3394,11 @@ def _rewrite_marker_page_locators(target, report):
     report.page_locator_count = emitted
     report.page_printed_count = captured
     report.page_printed_coverage = captured / emitted if emitted else 0.0
-    report.page_numbering = "printed" if captured else "pdf_only"
+    # Measured on the samples the offset decision used; see the pymupdf path.
+    offset_support = offset_support_at_derivation
+    report.page_printed_offset_support = offset_support
+    report.page_numbering = _decide_page_numbering(
+        captured, offset_consistent, offset_support)
     report.page_printed_offset = offset
     report.page_printed_offset_consistent = offset_consistent
     print(f"  page locators: {emitted} pages, {captured} printed numbers "

--- a/report.py
+++ b/report.py
@@ -65,6 +65,13 @@ class ConversionReport:
     page_printed_coverage: float = 0.0
     page_printed_offset: int | None = None
     page_printed_offset_consistent: bool = False
+    # Fraction of captured arabic folios carrying the best-supported offset.
+    # None when there were too few samples to speak of support. This number was
+    # always computed to decide consensus and then discarded, which left the
+    # only record of it inside warning prose -- so the difference between a
+    # book that renumbers once (84% support) and one whose folios are not page
+    # numbers at all (3%) was unreadable by anything but a human.
+    page_printed_offset_support: float | None = None
     # Heading signals. EPUB is reflowable, so `page_numbering` is always
     # "none" and headings are the *only* addressability an epub has — which
     # makes a structureless conversion otherwise indistinguishable from a

--- a/tests/test_page_numbering_offset_consistency.py
+++ b/tests/test_page_numbering_offset_consistency.py
@@ -1,0 +1,226 @@
+"""`page_numbering: printed` is a licence to cite, and must be earned.
+
+WHY THIS EXISTS
+
+mc-wiki's `tools/cite.py` refuses to cite a source by page unless its
+`page_numbering` reads "printed". So this one string decides whether page
+numbers out of a conversion can reach a citation.
+
+It used to be set from `captured > 0` alone — any folio anywhere earned the
+licence, however incoherent the pagination.
+
+Found 2026-09-01 by the annotated edition of *The Human Side of Enterprise*:
+30 folios captured across 480 sheets (coverage 0.062), with the sidecar
+stating that the best-supported offset was carried by 1 of 30 (3%, against an
+85% consensus bar) — and `page_numbering` still reading "printed". The captured
+values were sheet 56 -> "1", 72 -> "2", 85 -> "4", 99 -> "3", i.e. the
+annotated edition's marginal annotation numbers read as folios.
+"""
+import pytest
+
+from convert import (_decide_page_numbering, _page_offset_support,
+                     _page_offset_outliers)
+
+
+def test_no_folios_is_pdf_only():
+    assert _decide_page_numbering(0, False, None) == "pdf_only"
+    assert _decide_page_numbering(0, True, 1.0) == "pdf_only"
+
+
+def test_a_consistent_offset_earns_printed():
+    """The green case: the licence is still granted where it is deserved."""
+    assert _decide_page_numbering(127, True, 1.0) == "printed"
+    assert _decide_page_numbering(3, True, 1.0) == "printed"
+
+
+def test_incoherent_folios_lose_the_licence():
+    """The McGregor case, and the whole point of the change.
+
+    30 folios captured across 480 sheets, the dominant offset carried by 1 of
+    them. Those were the annotated edition's marginal annotation numbers.
+    """
+    assert _decide_page_numbering(30, False, 1 / 30) == "pdf_only"
+
+
+def test_a_book_that_merely_RENUMBERS_keeps_the_licence():
+    """The half the first draft of this fix got wrong.
+
+    Refusing every inconsistent book would have demoted 22 real sources,
+    including The Achievement Motive (67% support, 340 folios, 89.5% coverage)
+    and Scaling People (99.2% coverage). Renumbering is ordinary; incoherence
+    is not. Every support figure observed in the corpus outside McGregor:
+    """
+    for support in (0.54, 0.57, 0.67, 0.75, 0.77, 0.79, 0.84):
+        assert _decide_page_numbering(200, False, support) == "printed", support
+
+
+def test_the_threshold_sits_in_the_observed_gap():
+    """3% and 54% are the two neighbours; the boundary must separate them."""
+    assert _decide_page_numbering(30, False, 0.03) == "pdf_only"
+    assert _decide_page_numbering(30, False, 0.54) == "printed"
+
+
+def test_unjudgeable_support_leaves_the_verdict_alone():
+    """Too few samples is a DIFFERENT defect (sparse capture), out of scope.
+
+    Widening into it would demote four more sources on a question this change
+    did not investigate.
+    """
+    assert _decide_page_numbering(1, False, None) == "printed"
+    assert _decide_page_numbering(2, False, None) == "printed"
+
+
+def test_support_is_computed_from_the_samples():
+    # Six arabic folios: five at offset -5, one dissenting at -3.
+    samples = {10: "5", 11: "6", 12: "7", 13: "8", 14: "9", 20: "17"}
+    support = _page_offset_support(samples)
+    assert support == pytest.approx(5 / 6)
+
+
+def test_support_is_none_below_the_sample_floor():
+    assert _page_offset_support({10: "5"}) is None
+    assert _page_offset_support({}) is None
+
+
+@pytest.mark.parametrize("captured,consistent,support,expected", [
+    (0, False, None, "pdf_only"),
+    (1, True, 1.0, "printed"),
+    (30, False, 0.03, "pdf_only"),   # the-human-side-of-enterprise-annotated
+    (13, False, 0.54, "printed"),    # on-the-edge
+    (340, False, 0.67, "printed"),   # the-achievement-motive
+    (127, True, 1.0, "printed"),     # fitzpatrick-the-mom-test
+])
+def test_truth_table(captured, consistent, support, expected):
+    assert _decide_page_numbering(captured, consistent, support) == expected
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: derive support from a real sample map, not an injected number.
+#
+# codex round 1 caught that every test above hands `_decide_page_numbering` a
+# support value directly, so deleting the argument from BOTH production call
+# sites would leave them all green. These drive the actual derivation path.
+# ---------------------------------------------------------------------------
+
+from convert import _derive_page_offset
+
+
+def _mcgregor_like():
+    """The annotated-edition shape: captured values that are not folios.
+
+    Sheet 56 -> "1", 72 -> "2", 85 -> "4", 99 -> "3" and so on: marginal
+    annotation numbers, each giving a different offset.
+    """
+    return {56: "1", 72: "2", 85: "4", 99: "3", 113: "5", 130: "6",
+            148: "7", 161: "8", 177: "9", 190: "10"}
+
+
+def _coherent_book(n=40, offset=-5):
+    return {i: str(i + offset) for i in range(10, 10 + n)}
+
+
+def _renumbering_book():
+    """Coherent body plus a second sequence — the case that must SURVIVE."""
+    d = {i: str(i - 5) for i in range(10, 40)}      # 30 samples at -5
+    d.update({i: str(i - 60) for i in range(70, 82)})  # 12 at -60
+    return d
+
+
+def test_end_to_end_incoherent_captures_lose_the_licence():
+    samples = _mcgregor_like()
+    offset, consistent = _derive_page_offset(samples)
+    support = _page_offset_support(samples)
+    assert consistent is False
+    assert support < 0.5, support
+    assert _decide_page_numbering(len(samples), consistent, support) == "pdf_only"
+
+
+def test_end_to_end_a_coherent_book_keeps_the_licence():
+    samples = _coherent_book()
+    offset, consistent = _derive_page_offset(samples)
+    support = _page_offset_support(samples)
+    assert consistent is True and support == 1.0
+    assert _decide_page_numbering(len(samples), consistent, support) == "printed"
+
+
+def test_end_to_end_a_renumbering_book_keeps_the_licence():
+    """30 of 42 samples agree — refused as an offset, but far from incoherent."""
+    samples = _renumbering_book()
+    offset, consistent = _derive_page_offset(samples)
+    support = _page_offset_support(samples)
+    assert consistent is False
+    assert support > 0.5, support
+    assert _decide_page_numbering(len(samples), consistent, support) == "printed"
+
+
+def test_support_is_measured_before_outliers_are_removed():
+    """The ordering bug codex round 1 found (P2).
+
+    The production paths delete every capture contradicting an adopted offset.
+    Measuring support after that sweep reads ~1.0 for any book that got an
+    offset, which is both useless and a false description of the field.
+    """
+    samples = dict(_coherent_book(n=17))
+    samples[100] = "1"            # one contradicting capture
+    before = _page_offset_support(samples)
+    assert before == pytest.approx(17 / 18)
+
+    offset, consistent = _derive_page_offset(samples)
+    outliers = _page_offset_outliers(samples, offset if consistent else None)
+    for i in outliers:
+        del samples[i]
+    after = _page_offset_support(samples)
+    assert after == 1.0
+    assert before != after, "the sweep must actually change the figure"
+
+
+# ---------------------------------------------------------------------------
+# The integration test. Everything above calls the decision function directly,
+# so deleting the support argument from the production call sites leaves them
+# green — codex round 1 pointed that out and it was still true after the first
+# round of "end-to-end" tests. This one runs a real conversion and reads the
+# verdict off the report, which is the only thing that can catch it.
+# ---------------------------------------------------------------------------
+
+from tests.fixtures import build_page_printed_pdf
+
+
+def test_conversion_of_an_incoherent_book_reports_pdf_only(tmp_path):
+    """A book whose captured folios do not agree must not be called citable.
+
+    Every page prints a number, but the numbers are mutual nonsense — the
+    shape the annotated Human Side of Enterprise produced when marginal
+    annotation numbers were read as folios.
+    """
+    import convert
+    nonsense = {i: str((i * 7) % 11 + 1) for i in range(1, 21)}
+    pdf = build_page_printed_pdf(
+        tmp_path, pages=20, offset=-4,
+        misread_page_printed_on=nonsense, name="incoherent.pdf")
+
+    outdir = tmp_path / "out"
+    outdir.mkdir()          # this branch is independent of the sibling PR that
+                            # makes convert_with_pymupdf create its own outdir
+    report = convert.convert_with_pymupdf(pdf, outdir)
+
+    assert report.page_printed_count > 0, "fixture must capture folios"
+    assert report.page_printed_offset_consistent is False
+    assert report.page_printed_offset_support is not None
+    assert report.page_printed_offset_support < 0.5, \
+        report.page_printed_offset_support
+    assert report.page_numbering == "pdf_only", (
+        "captured folios that do not cohere must not earn the citation licence"
+    )
+
+
+def test_conversion_of_a_coherent_book_still_reports_printed(tmp_path):
+    """The other half: an ordinary book keeps its page-citability."""
+    import convert
+    pdf = build_page_printed_pdf(tmp_path, pages=20, offset=-4,
+                                 name="coherent.pdf")
+    outdir = tmp_path / "out2"
+    outdir.mkdir()
+    report = convert.convert_with_pymupdf(pdf, outdir)
+    assert report.page_printed_offset_consistent is True
+    assert report.page_numbering == "printed"
+    assert report.page_printed_offset_support == 1.0


### PR DESCRIPTION
`page_numbering` decides whether page numbers out of a conversion can reach a citation: mc-wiki's `tools/cite.py` refuses to cite by page unless it reads `printed`. It was granted on `captured > 0` alone, so **any** folio anywhere earned it, however incoherent the pagination.

## The book that found it

The annotated edition of *The Human Side of Enterprise*, 2026-09-01: **30 folios captured across 480 sheets** (coverage 0.062), the dominant offset carried by **1 of 30 (3%)** against an 85% consensus bar — and the headline verdict still reading `printed`.

| sheet | captured "folio" |
|---|---|
| 56 | 1 |
| 72 | 2 |
| 85 | 4 |
| 99 | 3 |

Sixteen sheets cannot separate printed pages 1 and 2, and 85 cannot precede 99 while carrying the higher number. These are the annotated edition's **marginal annotation numbers** read as folios.

The sidecar already said so, plainly, in its warning. Nothing acted on it. Filing that book on its headline verdict would have manufactured exactly the fabricated-page-number hazard that `thiel-zero-to-one` was stamped to correct the same night — where a chapter cited at p. 154 in fact begins at p. 118.

## The first draft of this fix was wrong, and that shaped it

Refusing every `offset_consistent: false` book demotes **22 sources**, including *The Achievement Motive* (340 folios, 89.5% coverage) and *Scaling People* (99.2%). Those are not incoherent — they renumber partway through, or carry two sequences, which is ordinary and which `page_correspondence_checked` already exists to adjudicate. Checking only that the bad case was fixed would have stripped page-citability from twenty-one good books.

So the discriminator is the **support** for the dominant offset — a number `_dominant_page_offset` already computed to decide consensus and then threw away, leaving its only record inside warning prose. It is now a first-class field, `page_printed_offset_support`.

The threshold is read off the corpus, not tuned. Support among the 22:

```
 3%  |  54, 57, 67, 75, 77, 79, 84, 84%  |  rest cleared the 85% bar
     ^ 51-point gap
```

`0.5` sits in that gap. The rule is *"the captured folios do not cohere at all"*, not *"this book renumbers somewhere"*.

## Verification, both directions

- **Blast radius against the real corpus: exactly 1 source flips** (`the-human-side-of-enterprise-annotated`, 3% support). 21 unchanged.
- 20 tests, including every support figure observed in the corpus and the two neighbours either side of the threshold.
- New tests run **RED against the previous rule**.
- An **integration test runs a real conversion** and asserts the report — verified to fail when the support argument is dropped from the production call site.
- Full suite: **394 passed, 9 skipped**.

## AI review — rounds: 2, engine: codex, verdict: pass with documented boundaries

Round 1 raised five findings. Three are fixed: support was being measured **after** the outlier sweep (so it read ~1.0 for any book that got an offset), the tests could not catch the production argument being dropped, and the commit had accidentally tracked a machine-specific `.venv` symlink.

Round 2 confirmed those and left three, all deliberate and now documented **in the docstring** rather than in a tracker:

1. **Fewer than three captured folios keeps the old verdict.** With no derived offset nothing is interpolated — the markers present are captured values, not manufactured ones. Demoting on sparseness is a different judgement about a different defect and would move four more sources on a question this change did not investigate.
2. **Support is measured over the captured population, not the emitted one.** Deliberate: it exists to describe the same evidence `_derive_page_offset` judged.
3. **A global modal share is blunt** — a three-sequence omnibus scores ~0.33 and is demoted. That is the intended reading: in such a volume "p. 50" does not identify a page without naming the sequence.

Closes AndySparks/mc-wiki#121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)