### PR TITLE
Preserve page mapping and file hashes in conversion reports

### DIFF
--- a/1-ROADMAP.md
+++ b/1-ROADMAP.md
@@ -2,7 +2,7 @@
 type: roadmap
 scope: sourceconvert
 status: active
-last_updated: 2026-04-27
+last_updated: 2026-09-05
 ---
 
 # sourceconvert — Roadmap
@@ -10,13 +10,15 @@ last_updated: 2026-04-27
 > Rolling punch list (Now / Next / Blocked / Someday). Update as work moves; drop items the moment they're done.
 > Loaded into Claude sessions automatically via `CLAUDE.md`.
 >
-> Renamed from `docs/TASKS.md` on 2026-04-27 as part of the spine adoption (`8-DECISIONS/2026-04-27-spine-adoption.md`). Same role, spine-aligned filename and frontmatter.
+> Renamed from `docs/1-ROADMAP.md` on 2026-04-27 as part of the spine adoption (`8-DECISIONS/2026-04-27-spine-adoption.md`). Same role, spine-aligned filename and frontmatter.
 >
 > sourceconvert is a small tool and does not carry a `0-STRATEGY.md`. For strategic context on why it exists, see the Management Craft STRATEGY.md under the MC Research Loop Acquire step. Publicly trackable bugs and features live in GitHub Issues at https://github.com/AndySparks/sourceconvert/issues.
 
 ## Now
 
 _none currently_
+
+September 5: conversion reports now retain per-page observed/inferred locator provenance and source/output hashes. Verified with the paired mc-wiki ingestion changes (413 converter tests pass).
 
 ## Next
 
@@ -48,10 +50,10 @@ _none currently_
 - **Remove** items the moment they're done. No archive. Git log is the history.
 - **Move** items between buckets as priority shifts.
 - `/start` surfaces items from "Now" and "Blocked" when opening the repo.
-- `/wrap` prompts to update TASKS.md at session end.
+- `/wrap` prompts to update 1-ROADMAP.md at session end.
 
 ## What does NOT go here
 
 - **Publicly trackable bugs and features**: GitHub Issues, with a link here if blocking active work in this repo.
-- **MC-wide tasks that happen to touch sourceconvert**: Management Craft's `docs/TASKS.md`. sourceconvert is infrastructure for MC's Research Loop Acquire step; strategic questions about the corpus live upstream.
+- **MC-wide tasks that happen to touch sourceconvert**: Management Craft's `docs/1-ROADMAP.md`. sourceconvert is infrastructure for MC's Research Loop Acquire step; strategic questions about the corpus live upstream.
 - **Cross-project personal admin**: Notion Tasks DB.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ The marginal cost of completeness is near zero with AI. Do the whole thing. Do i
 - **Never tell a consumer to pattern-match an asset filename.** `_page_N_Figure_M.jpeg` is marker's private convention. Relocating assets is done from the sidecar's `assets` manifest — `path` plus `references[].target` — which is stable across backends and across marker versions
 - If OCR output needs cleanup, help the user clean up the markdown: fix obvious OCR errors, add proper headings, remove page artifacts
 - Keep the markdown header format: title, "Converted from PDF" note, source filename, then `---` separator
-- Use `<!-- Page N -->` comments to mark page boundaries
+- Use typed `<!-- page_pdf=N page_printed=X -->` markers; PDF indices start at zero. Legacy `<!-- Page N -->` is not a print folio.
 - The `clean_title()` function strips version markers (e.g., "V3") from filenames for cleaner titles
 - Inspect the `.report.json` sidecar to see what happened: `jq '.method,.extracted_assets,.quality_score' output/*.report.json`
 
@@ -44,7 +44,7 @@ marker 2 needs `llama-server` (`brew install llama.cpp`) for its CPU/MPS backend
 
 ## Verifying a scan's page numbers
 
-`convert.py` reads printed folios where it can and **interpolates** the rest from a consensus offset. That leaves the output part measured and part computed, and nothing downstream can tell which is which. The failure it cannot survive is a **pagination shift** — an unnumbered plate section or bound-in map — because one constant offset is then applied over the top and every folio past it is smoothly, self-consistently wrong.
+`convert.py` reads printed folios where it can and **interpolates** the rest from a consensus offset. The report now records `page_map` entries with `method: observed | inferred | none`, bound to original/output SHA-256. Downstream consumers can distinguish observed numbers from interpolation; older reports cannot. The failure it cannot survive is a **pagination shift** — an unnumbered plate section or bound-in map — because one constant offset is then applied over the top and every folio past it is smoothly, self-consistently wrong.
 
 `python verify_folios.py <pdf>` reads the folios back off the page images and reports it. Exit 0 no shift, 1 a shift (folios past it are suspect), **2 too few folios read to say anything — which is not a pass**. `--json` for a machine-readable verdict.
 

--- a/convert.py
+++ b/convert.py
@@ -3244,6 +3244,8 @@ def convert_with_pymupdf(pdf_path, output_dir, extract_images=True):
                 # printed page 1.
                 if candidate >= 1:
                     effective_page_printed = str(candidate)
+            report.page_map.append({"page_pdf": page_num, "page_printed": effective_page_printed,
+                                    "method": "observed" if page_printed is not None else "inferred" if effective_page_printed is not None else "none"})
             f.write(f"<!-- page_pdf={page_num} page_printed={effective_page_printed or 'none'} -->\n\n")
             emitted_locator_pages += 1
             # `page_printed`, not `effective_page_printed`: page_printed_count
@@ -3396,6 +3398,8 @@ def _rewrite_marker_page_locators(target, report):
             candidate = index + offset
             if candidate >= 1:
                 effective = str(candidate)
+        report.page_map.append({"page_pdf": index, "page_printed": effective,
+                                "method": "observed" if printed is not None else "inferred" if effective is not None else "none"})
         out.append(f"<!-- page_pdf={index} page_printed={effective or 'none'} -->\n")
         emitted += 1
         if printed:

--- a/report.py
+++ b/report.py
@@ -9,6 +9,8 @@ and any warnings.
 from __future__ import annotations
 
 import json
+import hashlib
+from functools import lru_cache
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import List
@@ -21,6 +23,10 @@ class ConversionReport:
     source: str
     output: str
     method: str
+    source_sha256: str | None = None
+    output_sha256: str | None = None
+    # One entry per emitted PDF marker; method says read, interpolated or absent.
+    page_map: list = field(default_factory=list)
     total_pages: int = 0
     pages_with_text: int = 0
     ocr_pages: int = 0
@@ -91,9 +97,29 @@ class ConversionReport:
         return asdict(self)
 
 
+@lru_cache(maxsize=16)
+def _digest(path, signature):
+    h = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
 def write_report(path: Path, report: ConversionReport) -> None:
     """Write a ConversionReport to a JSON sidecar at `path`."""
     path = Path(path)
+    for field_name, file_name in (("source_sha256", report.source), ("output_sha256", report.output)):
+        original = Path(file_name) if file_name else None
+        if original is not None and original.is_file():
+            st = original.stat()
+            setattr(report, field_name, _digest(str(original.resolve()),
+                    (st.st_size, st.st_mtime_ns, st.st_ctime_ns)))
+        else:
+            setattr(report, field_name, None)
+            warning = f"{field_name} unavailable: file is missing"
+            if warning not in report.warnings:
+                report.warnings.append(warning)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(report.to_dict(), indent=2, ensure_ascii=False) + "\n",

--- a/tests/test_page_evidence.py
+++ b/tests/test_page_evidence.py
@@ -1,0 +1,23 @@
+import hashlib
+import json
+from report import ConversionReport, write_report
+import convert
+
+
+def test_report_binds_original_and_output(tmp_path):
+    source = tmp_path / 'a.pdf'; source.write_bytes(b'original')
+    out = tmp_path / 'a.md'; out.write_text('text')
+    r = ConversionReport(source=str(source), output=str(out), method='marker')
+    write_report(tmp_path / 'report.json', r)
+    assert r.source_sha256 == hashlib.sha256(b'original').hexdigest()
+    assert r.output_sha256 == hashlib.sha256(b'text').hexdigest()
+
+
+def test_marker_mapping_distinguishes_read_and_inferred(tmp_path, monkeypatch):
+    p = tmp_path / 'a.md'; p.write_text('fixture')
+    monkeypatch.setattr(convert, '_marker_page_locators', lambda text: ([(i, 'body') for i in range(10, 21)], {10:'1',11:'2',12:'3',18:'9',19:'10',20:'11'}))
+    r = ConversionReport(source='x', output=str(p), method='marker')
+    convert._rewrite_marker_page_locators(p, r)
+    assert r.page_map[0]['method'] == 'observed'
+    assert r.page_map[3]['method'] == 'inferred'
+    assert r.page_map[3]['page_printed'] == '4'


### PR DESCRIPTION
Conversion reports previously lost whether each printed folio was observed or inferred, so downstream checking could demote legitimate page-offset shifts. Reports now retain a per-page evidence map and source/output SHA-256 hashes, allowing mc-wiki to recognize an exact, fully observed map tied to the original.

Hashes are cached by file signature; missing files produce explicit warnings. Existing marker syntax and inference behavior remain compatible. Paired consumer: AndySparks/mc-wiki branch `agent/ingestion-v2`, commit `ba3dc86`; process documentation: AndySparks/management-craft branch `AndySparks/audit-book-ingestion`.

Validation: 413 tests passed, 2 skipped, including hash binding and observed/inferred page-map tests. Paired vault suite: 2,870 passed; real PDF routing fixtures and shell integration suites pass. No production source was converted or modified.

## AI review — rounds: 2, engine: claude, verdict: changes requested and fixed

Claude reviewed both paired diffs. Fixed repeated digest work, explicit missing-file evidence, None handling and restored Path coercion. The extra round was for revised vault routing/cache mechanisms; its B2 wiring finding was fixed in that paired branch with a failing-before/passing-after regression. Both reviews requested changes; this records resolved actionables rather than claiming an unconditional approval.
